### PR TITLE
QueryPie Terraform 설치를 위한 .gitignore 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,21 @@
 
 # Ignore .DS_Store files in any directory.
 .DS_Store
+
+# Ignore Terraform directories and state files
+**/.terraform/*
+*.tfstate
+*.tfstate.*
+.terraform.lock.*
+
+# Ignore QueryPie license file
+.license.crt
+
+# Ignore QueryPie Docker registry credentials
+.docker-config.json
+
+# Ignore QueryPie Terraform variable definitions
+.querypie.tfvars
+
+# Ignore AWS private key files
+*.pem


### PR DESCRIPTION
다음 파일들이 Git 저장소에 포함되지 않도록 설정합니다.
- Terraform 디렉터리 및 상태 파일(.terraform/, *.tfstate 등)
- QueryPie 라이선스 파일(.license.crt)
- QueryPie Docker 레지스트리 자격 증명(.docker-config.json)
- QueryPie Terraform 설정 파일(.querypie.tfvars)
- AWS 개인 키 파일(*.pem)