### PR TITLE
Fix: QueryPie 컨테이너 자동 감지 로직 개선 및 변수 사용 오류 수정

### DIFF
--- a/cs-reporter/querypie_cs_report.sh
+++ b/cs-reporter/querypie_cs_report.sh
@@ -28,7 +28,7 @@ print_banner() {
 
 QUERYPIE_NAME=$1
 if [ -z "$QUERYPIE_NAME" ]; then
-	QUERYPIE_NAME=$(docker ps --filter "name=^querypie" --format "{{.Names}}")
+	QUERYPIE_NAME=$(docker ps --filter "name=^querypie-app" --format "{{.Names}}")
 else
 	QUERYPIE_NAME_EXISTS=$(docker ps --filter name="^$QUERYPIE_NAME$" --format "{{.Names}}")
 	if [ -z "$QUERYPIE_NAME_EXISTS" ]; then
@@ -73,8 +73,8 @@ netstat -an > $OUTPUT_DIR/netstat
 echo -n "Listening... : "
 cat $OUTPUT_DIR/netstat | grep LISTEN | egrep ^tcp | fgrep LISTEN | wc -l
 
-docker exec querypie /sbin/ifconfig > $OUTPUT_DIR/docker_ifconfig
-docker exec querypie netstat -an > $OUTPUT_DIR/docker_netstat
+docker exec $QUERYPIE_NAME /sbin/ifconfig > $OUTPUT_DIR/docker_ifconfig
+docker exec $QUERYPIE_NAME netstat -an > $OUTPUT_DIR/docker_netstat
 echo -n "Docker Listening... : "
 cat $OUTPUT_DIR/docker_netstat | grep LISTEN | egrep ^tcp | fgrep LISTEN | wc -l
 


### PR DESCRIPTION
- QueryPie 컨테이너 자동 감지 시 `querypie-app`으로 시작하는 컨테이너를 우선적으로 선택하도록 필터 수정. (기존: `name=^querypie` -> 변경: `name=^querypie-app`) 이를 통해 인자 없이 스크립트 실행 시 `querypie-redis` 등 다른 서비스 컨테이너가 잘못 선택되는 문제 해결.

- 컨테이너 내부 네트워크 정보 수집 시 `docker exec` 명령어에서 하드코딩된 'querypie' 대신 `$QUERYPIE_NAME` 변수를 사용하도록 수정.