### PR TITLE
AMI 빌드 - init-compose-env.sh 스크립트 도입

### DIFF
--- a/aws-ami/scripts/init-compose-env.sh
+++ b/aws-ami/scripts/init-compose-env.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+
+set -o nounset -o errexit -o errtrace -o pipefail
+
+BOLD_CYAN="\e[1;36m"
+BOLD_RED="\e[1;91m"
+RESET="\e[0m"
+
+function log::do() {
+  # print ascii color code for bold cyan and reset
+  printf "%b+ %s%b\n" "$BOLD_CYAN" "$*" "$RESET" 1>&2
+  if "$@"; then
+    return 0
+  else
+    log::error "Failed to run: $*"
+    return 1
+  fi
+}
+
+function log::error() {
+  printf "%bERROR: %s%b\n" "$BOLD_RED" "$*" "$RESET" 1>&2
+}
+
+function random_hex() {
+  local length=${1:-32}
+  if command -v openssl >/dev/null; then
+    openssl rand -hex $((length / 2))
+    return 0
+  fi
+  if command -v xxd >/dev/null; then
+    xxd -l "$((length / 2))" -p /dev/urandom
+    return 0
+  fi
+  log::error "Cannot generate a random hex string."
+  log::error "Please make sure that you have openssl(1) or xxd(1) installed in the host."
+  exit 1
+}
+
+function read_user_input() {
+  local prompt=$1 default=$2 value
+  if [[ -t 0 ]]; then
+    read -r -p "${prompt} [${default}]: " value
+    echo "${value:-${default}}"
+  else
+    echo "${default}"
+  fi
+}
+
+function determine_value() {
+  local name=$1 existing_value=$2
+
+  # Priority 1: Use the value from the environment if it exists.
+  if [[ -n "${!name:-}" ]]; then
+    echo "${!name}"
+    return
+  fi
+
+  # Priority 2: Use the value from the source file if it exists.
+  if [[ -n "${existing_value}" ]]; then
+    echo "${existing_value}"
+    return
+  fi
+
+  # Priority 3: Provide default values for specific variables.
+  case "${name}" in
+  AGENT_SECRET)
+    random_hex 32
+    ;;
+  KEY_ENCRYPTION_KEY)
+    random_hex 12
+    ;;
+  DB_PASSWORD | REDIS_PASSWORD)
+    random_hex 8
+    ;;
+  DB_HOST)
+    echo host.docker.internal
+    ;;
+  DB_USERNAME)
+    echo querypie
+    ;;
+  REDIS_NODES)
+    echo host.docker.internal:6379
+    ;;
+  *)
+    log::error "Unexpected variable: ${name}"
+    ;;
+  esac
+}
+
+function generate_env() {
+  local source_env=$1 line name value existing_value
+  while IFS= read -r -u 9 line; do
+    if [[ -z "${line}" || "${line}" =~ ^\s*# ]]; then
+      # Skip empty lines and comments.
+      echo "${line}"
+      continue
+    fi
+
+    name=${line%%=*}
+    existing_value=${line#*=}
+    value=$(determine_value "${name}" "${existing_value}")
+    echo "${name}=${value}"
+  done 9<"${source_env}" # 9 is unused file descriptor to read ${source_env}.
+}
+
+function main() {
+  if [[ $# -lt 0 ]]; then
+    echo "Usage: $0 <compose-env>"
+    exit 1
+  fi
+  local source_env=$1
+  if [[ ! -r "${source_env}" ]]; then
+    log::error "Cannot read the source environment file: ${source_env}"
+    exit 1
+  fi
+
+  echo >&2 "## Generating a docker env file from ${source_env}..."
+  generate_env "${source_env}"
+}
+
+main "$@"


### PR DESCRIPTION
## Changes
- `compose-env`의 환경변수값을 기본값으로 채워주는 `init-compose-env.sh` 스크립트를 도입합니다.
  - SECRET, PASSWORD 등 Credential 에 해당하는 값은 Random value 로 생성합니다.
  - 1대 VM 에서 MySQL, Redis 가 작동하는 PoC 환경을 가정하고, 환경변수 값을 채워줍니다.
  - 환경변수값이 미리 정의되어 있는 경우, 그 값을 사용합니다.
- 우선순위
  1. 현재 정의된 환경변수의 값
  2. source 가 되는 compose-env 파일에 기본 설정된 값
  3. 스크립트에서 생성하여 제공하는 값

## Testing

```
jk@Jk-Kim-VVVY6C7KYV aws-ami % VERSION=10.3.0 ./scripts/init-compose-env.sh ../../querypie-mono/deploy/operation/10.3.x/compose-env 2>/dev/null
# Version of QueryPie Docker Image to run: 10.3.0 or later.
VERSION=10.3.0

# Common
## Secret key for encrypting communication between QueryPie client agents and QueryPie over port 9000/tcp.
## Must be exactly 32 characters in length.
AGENT_SECRET=0120c7e558132e383aa51f5c0d8125c9

## Secret key used to encrypt sensitive information, such as database connection strings and SSH private keys.
## This key can be any string but is immutable once set.
KEY_ENCRYPTION_KEY=121442fddc27

# DB
DB_HOST=host.docker.internal
DB_PORT=3306
DB_CATALOG=querypie
LOG_DB_CATALOG=querypie_log
ENG_DB_CATALOG=querypie_snapshot
DB_USERNAME=querypie
DB_PASSWORD=bba90042
DB_MAX_CONNECTION_SIZE=20
## If you’re using AWS Aurora, use the software.amazon.jdbc.Driver instead of org.mariadb.jdbc.Driver for automatic failover handling.
DB_DRIVER_CLASS=org.mariadb.jdbc.Driver

# Redis
## REDIS_NODES should be specified as a “Host:Port” combination.
## In CLUSTER MODE, when specifying multiple nodes, separate each address with a comma.
## Example: Host1:6379,Host2:6379,Host3:6379
REDIS_NODES=host.docker.internal:6379
REDIS_PASSWORD=90243d1b

DAC_SKIP_SQL_COMMAND_RULE_FILE=skip_command_config.json
jk@Jk-Kim-VVVY6C7KYV aws-ami % 
```