### PR TITLE
AMI 빌드 - Docker Image 내려받기를 구현합니다.

### DIFF
--- a/aws-ami/README.md
+++ b/aws-ami/README.md
@@ -34,17 +34,29 @@ Suppose you are building on macOS.
     ```bash
     packer init querypie-ami.pkr.hcl
     ```
+6. Modify docker-config.json by populating the auth value.
+    ```json
+   {
+     "auths": {
+       "harbor.chequer.io": {
+         "auth": "<base64-encoded-username:password>"
+       }
+     }
+   }
+    ```
+   To generate the auth value, run: `echo -n 'username:password' | base64`
 
 ## Build an AMI
 
 Run `build-ami.sh <version>` to build an AMI where <version> is a version of QueryPie.
-    `./build-ami.sh 10.3.0`
+`./build-ami.sh 10.3.0`
 
 ## Troubleshooting
 
 ### An error occurred (UnauthorizedOperation) when calling the DescribeImages operation
 
 You may encounter the following error when running Packer:
+
 ```
 An error occurred (UnauthorizedOperation) when calling the DescribeImages operation: 
   You are not authorized to perform this operation. 
@@ -56,6 +68,7 @@ This error indicates that your IAM user does not have the necessary permissions 
 To resolve this, you need to attach a policy that allows the `ec2:DescribeImages` action to your IAM user.
 
 Steps to resolve the issue:
+
 1. Go to the [IAM Management Console](https://console.aws.amazon.com/iam/home).
 2. Select your IAM user.
 3. Click on the "Add permissions" button.

--- a/aws-ami/docker-config.json
+++ b/aws-ami/docker-config.json
@@ -1,0 +1,7 @@
+{
+  "auths": {
+    "harbor.chequer.io": {
+      "auth": "<base64-encoded-username:password>"
+    }
+  }
+}

--- a/aws-ami/querypie-ami.pkr.hcl
+++ b/aws-ami/querypie-ami.pkr.hcl
@@ -76,7 +76,7 @@ source "amazon-ebs" "amazon-linux-2023" {
   # Root volume configuration
   launch_block_device_mappings {
     device_name           = "/dev/xvda"
-    volume_size           = 20
+    volume_size           = 30
     volume_type           = "gp3"
     iops                  = 3000
     throughput            = 125
@@ -135,15 +135,17 @@ build {
     ]
   }
 
-  # Install QueryPie
+  # Install QueryPie Deployment Package
   provisioner "shell" {
     inline = [
       "set -o xtrace",
       "pwd",
       "curl -L https://dl.querypie.com/releases/compose/setup.sh -o setup.sh",
       "QP_VERSION=${var.querypie_version} bash setup.sh",
+      "[[ -d ~/.docker ]] || mkdir -p ~/.docker",
     ]
   }
+
   # Setup docker environment file
   provisioner "shell" {
     environment_vars = [
@@ -152,11 +154,32 @@ build {
     script = "scripts/init-compose-env.sh"
   }
 
+  # Setup .docker/config.json for Docker registry authentication
+  provisioner "file" {
+      source      = "docker-config.json"
+      destination = ".docker/config.json"
+  }
+
+  # Pull QueryPie Docker Images
+  provisioner "shell" {
+    inline = [
+      "set -o xtrace",
+      "find ~ -ls", # TODO(JK): Debugging purpose, remove later
+      "cd querypie/${var.querypie_version}",
+      "ln -s compose-env .env",
+      "docker-compose pull app tools mysql redis --quiet",
+      "docker image ls",
+      "docker container ls --all",
+    ]
+  }
+
   # Final cleanup
   provisioner "shell" {
     inline = [
       "echo '# Performing final cleanup...'",
       "set -o xtrace",
+      "find ~ -ls", # TODO(JK): Debugging purpose, remove later
+      "rm ~/.docker/config.json",
       "sudo dnf clean all",
       "sudo rm -rf /tmp/*",
       "sudo rm -rf /var/tmp/*",


### PR DESCRIPTION
## Changes
- Harbor Docker Registry 에 대한 인증 정보를 일시적으로 전송합니다.
  - `docker-config.json` 파일에 인증 정보를 설정한 이후, `./build-ami.sh` 를 실행하면 됩니다.
  - `docker-config.json` 파일의 설정 방법을 README.md 에 정리하였습니다.
- Docker Image 를 내려 받는 기능을, packer 스크립트에 구현합니다.
  - `docker compose` 명령이 작동하지 않기에, `docker-compose` 를 사용합니다.
  - 여러 docker image 를 한번에 내려받는 명령을 실행합니다.

## Testing
```
jk@Jk-Kim-VVVY6C7KYV aws-ami % ./build-ami.sh 10.3.0
### Build AMI with Packer ###
+ packer build -var querypie_version=10.3.0 -var ami_name_prefix=querypie-suite querypie-ami.pkr.hcl
build-querypie-ami.amazon-ebs.amazon-linux-2023: output will be in this color.

==> build-querypie-ami.amazon-ebs.amazon-linux-2023: Prevalidating any provided VPC information
==> build-querypie-ami.amazon-ebs.amazon-linux-2023: Prevalidating AMI Name: querypie-suite-10.3.0-20250613090932

<생략>

==> build-querypie-ami.amazon-ebs.amazon-linux-2023: + docker image ls
==> build-querypie-ami.amazon-ebs.amazon-linux-2023: REPOSITORY                                  TAG            IMAGE ID       CREATED         SIZE
==> build-querypie-ami.amazon-ebs.amazon-linux-2023: amazon/amazon-ecs-agent                     latest         65cd3d63c1c3   3 weeks ago     120MB
==> build-querypie-ami.amazon-ebs.amazon-linux-2023: harbor.chequer.io/querypie/querypie         10.3.0         6302ecc3e10d   4 weeks ago     3.79GB
==> build-querypie-ami.amazon-ebs.amazon-linux-2023: harbor.chequer.io/querypie/querypie-tools   10.3.0         77b6a64103de   4 weeks ago     341MB
==> build-querypie-ami.amazon-ebs.amazon-linux-2023: ecs-service-connect-agent                   interface-v1   c3db5c7ced40   2 months ago    170MB
==> build-querypie-ami.amazon-ebs.amazon-linux-2023: harbor.chequer.io/querypie/redis            7.4.2          65750d044ac8   5 months ago    117MB
==> build-querypie-ami.amazon-ebs.amazon-linux-2023: harbor.chequer.io/querypie/mysql            8.0.39         f5da8fc4b539   10 months ago   573MB
==> build-querypie-ami.amazon-ebs.amazon-linux-2023: amazon/amazon-ecs-pause                     0.1.0          9dd4685d3644   10 years ago    702kB
==> build-querypie-ami.amazon-ebs.amazon-linux-2023: + docker container ls --all
==> build-querypie-ami.amazon-ebs.amazon-linux-2023: CONTAINER ID   IMAGE                            COMMAND    CREATED          STATUS                     PORTS     NAMES
==> build-querypie-ami.amazon-ebs.amazon-linux-2023: 7b08e7459bc5   amazon/amazon-ecs-agent:latest   "/agent"   25 seconds ago   Exited (1) 5 seconds ago             ecs-agent
==> build-querypie-ami.amazon-ebs.amazon-linux-2023: Provisioning with shell script: /var/folders/9h/bj4nh9ss6pq0_2bkd39t0p0w0000gn/T/packer-shell3194019858
==> build-querypie-ami.amazon-ebs.amazon-linux-2023: + find /home/ec2-user -ls
==> build-querypie-ami.amazon-ebs.amazon-linux-2023: # Performing final cleanup...
==> build-querypie-ami.amazon-ebs.amazon-linux-2023: + rm /home/ec2-user/.docker/config.json
==> build-querypie-ami.amazon-ebs.amazon-linux-2023:    435310      0 drwx------   6 ec2-user ec2-user      135 Jun 13 09:12 /home/ec2-user
==> build-querypie-ami.amazon-ebs.amazon-linux-2023: + sudo dnf clean all

<생략>
```
