### PR TITLE
AMI 빌드 - setup.v2.sh 실행 방식 변경

### DIFF
--- a/aws-ami/scripts/setup.v2.sh
+++ b/aws-ami/scripts/setup.v2.sh
@@ -13,8 +13,10 @@ function print_usage_and_exit() {
   cat >&"${out}" <<END
 Usage: $program_name [options] <version>
     or $program_name [options] --install <version>
+    or $program_name [options] --install-partially-for-ami <version>
     or $program_name [options] --upgrade <version>
     or $program_name [options] --resume
+    or $program_name [options] --populate-env <compose-env-file>
     or $program_name [options] --help
 
 OPTIONS:
@@ -234,13 +236,12 @@ function package_version() {
   fi
 }
 
-function do_install() {
-  local qp_version=$1
-  QP_VERSION="${QP_VERSION:-${qp_version:-}}"
+function do_install_partially_for_ami() {
+  local QP_VERSION=${1:-}
 
+  echo >&2 "### Install partially for AWS AMI Build. ###"
   validate::action_and_version install "${QP_VERSION}"
   echo >&2 "# QP_VERSION: ${QP_VERSION}"
-
   PACKAGE_VERSION=$(package_version "${PACKAGE_VERSION:-}" "${QP_VERSION}")
   echo >&2 "# PACKAGE_VERSION: ${PACKAGE_VERSION}"
 
@@ -253,9 +254,9 @@ function do_install() {
 }
 
 function main() {
-  echo >&2 "### Welcome to QueryPie Installation! ###"
 
-  local action="install" qp_version=""
+  local -a argv=()
+  local action="install"
   while [[ $# -gt 0 ]]; do
     case "$1" in
     -x | --xtrace)
@@ -265,16 +266,12 @@ function main() {
     -h | --help)
       print_usage_and_exit 0
       ;;
-    --install)
-      action="install"
+    --install | --install-partially-for-ami | --upgrade | --resume)
+      action="${1#--}"
       shift
       ;;
-    --upgrade)
-      action="upgrade"
-      shift
-      ;;
-    --resume)
-      action="resume"
+    --populate-env)
+      action="${1#--}"
       shift
       ;;
     -*)
@@ -282,22 +279,20 @@ function main() {
       log::error "Unexpected option received: $1"
       print_usage_and_exit 1
       ;;
-    [0-9]*.[0-9]*.[0-9]*)
-      qp_version="$1"
-      shift
-      ;;
     *)
-      # Got unexpected arguments
-      log::error "Unexpected argument received: $1"
-      log::error "Please provide the version in the format ##.##.#, such as 10.3.1"
-      print_usage_and_exit 1
+      argv+=("$1")
+      shift
       ;;
     esac
   done
+  set -- "${argv[@]}"
 
   case "$action" in
   install)
-    do_install "$qp_version"
+    echo >&2 "# Install is not implemented yet."
+    ;;
+  install-partially-for-ami)
+    do_install_partially_for_ami "$@"
     ;;
   upgrade)
     echo >&2 "# Upgrade is not implemented yet."
@@ -305,6 +300,10 @@ function main() {
     ;;
   resume)
     echo >&2 "# Resuming installation is not implemented yet."
+    exit 1
+    ;;
+  populate-env)
+    echo >&2 "# populate-env is not implemented yet."
     exit 1
     ;;
   *)


### PR DESCRIPTION
## 변경사항

- setup.v2.sh 를 실행할 때, 설치 명령, 버전을 argument 로 넘겨 받는 방식으로, 실행 방식을 변경합니다.
  - 환경변수에서 대상을 입력받는 방식은, 이후 필요에 따라 구현할 예정입니다.
- 현재 구현 중인 기능은 --install-partially-for-ami 입니다.
- 사용법
```
Usage: setup.v2.sh [options] <version>
    or setup.v2.sh [options] --install <version>
    or setup.v2.sh [options] --install-partially-for-ami <version>
    or setup.v2.sh [options] --upgrade <version>
    or setup.v2.sh [options] --resume
    or setup.v2.sh [options] --populate-env <compose-env-file>
    or setup.v2.sh [options] --help

OPTIONS:
  -x, --xtrace        Print commands and their arguments as they are executed.
  -h, --help          Show this help message.

```

## 테스팅
- Local macbook 에서 기능 작동을 검증하였습니다.