### PR TITLE
AMI 빌드 - Refactor setup.v2.sh, packer script

### DIFF
--- a/aws-ami/ami-ls.sh
+++ b/aws-ami/ami-ls.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -o xtrace
+
+aws ec2 describe-images \
+  --owners self \
+  --query 'Images[*].{Name:Name,ImageId:ImageId,State:State,CreationDate:CreationDate,Description:Description,Architecture:Architecture,VirtualizationType:VirtualizationType}' \
+  --output table
+

--- a/aws-ami/querypie-ami.pkr.hcl
+++ b/aws-ami/querypie-ami.pkr.hcl
@@ -16,10 +16,10 @@ variable "querypie_version" {
   description = "Version of QueryPie to install"
 }
 
-variable "ami_name_prefix" {
+variable "ami_name" {
   type        = string
-  default     = "querypie"
-  description = "Prefix for AMI name"
+  default     = "QueryPie-Suite-0.0.0"
+  description = "AMI name"
 }
 
 variable "docker_auth" {
@@ -31,7 +31,7 @@ variable "docker_auth" {
 # Local variables
 locals {
   timestamp = regex_replace(timestamp(), "[- TZ:]", "")
-  ami_name = "${var.ami_name_prefix}-${var.querypie_version}-${local.timestamp}"
+  ami_name = "${var.ami_name}"
   region   = "ap-northeast-2"
   instance_type = "t3.xlarge" # Use t3.xlarge to accelerate the build process
   ssh_username = "ec2-user" # SSH username for Amazon Linux 2023


### PR DESCRIPTION
## 변경사항
- Refactor setup.v2.sh
  - Input validation 은 `function main()` 에서 수행하도록 변경합니다.
  - Command 등 기능을 수행하는 함수에서는, input 값의 유효성을 검사하지 않아도 됩니다.
  - 이를 통해, Input validation 코드를 더 간결하게 줄입니다.
- `ami-build.sh`
  - 기존 `build-ami.sh` 의 이름을 바꾸어, `ami-build.sh` 로 변경합니다. `ami-` 로 시작하는 스크립트들과 나란히 목록에 나타나도록 이름을 바꿉니다.
  - AMI 의 이름을, `ami-build.sh` 에서 결정합니다. Packer script 내부에서, 문자열을 조합하여 결정하지 않고, Caller 에서 결정하기에, AMI 이름을 따로 알아내지 않아도 됩니다.
  - 빌드 직후, `ami-build.sh`에서 생성된 AMI ID 를 알아내도록, 개선합니다.
- `ami-ls.sh` 도입
  - AWS 계정에 생성된 AMI 전체를 테이블 형식으로 조회합니다.

## 테스트 결과
- AMI 빌드에 성공합니다.