### PR TITLE
Podman: MySQL, Redis 를 위한 database.yml 을 구현합니다.

### DIFF
--- a/podman/README.md
+++ b/podman/README.md
@@ -1,0 +1,52 @@
+# Podman Compose, Docker Compose 모두를 위한 QueryPie 실행 환경
+
+Podman, Podman Compose 를 지원하는 QueryPie 실행 환경을 제공합니다.
+뿐만 아니라, Docker, Docker Compose 를 이용할 수도 있도록, 호환성을 유지하는 설정을 제공합니다.
+
+## QueryPie 실행하기
+
+### MySQL, Redis 실행하기, 종료하기
+
+1. compose-env 파일을 편집하여, 필요한 환경변수 값을 설정합니다.
+2. `podman-compose -f database.yml up -d` 명령으로 Container 를 실행합니다.
+3. `podman-compose -f database.yml down` 명령으로 Container 를 종료합니다.
+
+## Compose Yaml 의 변경사항
+
+- Profile 설정을 사용하지 않고, database.yml, querypie.yml, tools.yml 등 Compose Yaml 을 세 개로 분리합니다.
+  - Podman Compose 구버전은 Docker Compose 와 달리, Profile 설정을 지원하지 않습니다.
+  - 검증 범위를 좁히고, 실행 명령을 간단하게 만들기 위해, Profile 을 사용하지 않도록 변경합니다.
+- Container 이름을 지정할 때 사용하는 구분자를 `_`가 아닌 `-`를 사용하도록 설정을 추가합니다.
+  - Podman Compose 는 기본으로 `_`를 구분자로 사용합니다. Docker Compose v2 와 호환되려면, `-`를 사용해야 합니다.
+  - `x-podman: name_separator_compat: true` 라는 설정을 추가합니다.
+  - Docker Compose v1 은 `_`를 구분자로, v2 는 `-`를 구분자로 사용합니다.
+- MySQL 을 위한 `/var/lib/mysql` 데이터 디렉토리를 Host Filesystem 이 아닌 Container Volume 으로 제공합니다.
+  - Podman 에서는 Host Filesystem 을 제공하는 경우, 해당 디렉토리의 Ownership 을 변경하지 못하여, 오류가 발생합니다.
+- Docker Image 의 Registry 를 명시하여, `docker.io/` 라는 Registry 를 사용합니다.
+  - Registry 가 명시되지 않으면, Podman Compose 에서 이미지를 내려받을 때, RHEL 의 Registry 를 사용할 것인지 질문을 받게 됩니다.
+
+## Podman, Podman Compose 설치 방법
+
+Podman, Podman Compose 가 배포본 패키지로 제공되는 리눅스 배포본이 다수입니다.
+그러나, Amazon Linux 2023 에서는 Podman 설치 패키지가 제공되지 않습니다.
+
+- Podman 설치 방법
+  - `sudo dnf install podman`
+- Podman Compose 설치 방법
+  - `sudo dnf install -y python3.11 python3.11-pip python3.11-devel`
+  - `python3.11 -m pip install --user podman-compose`
+- 설치결과를 확인하기
+  - `podman --version`
+    - 4.9.4-rhel 또는 이후 버전인지 확인합니다.
+  - `python3.11 --version`
+  - `podman-compose --version`
+    - 1.5.0 또는 이후 버전인지 확인합니다.
+
+## 테스트 환경
+
+- Red Hat Enterprise Linux release 8.9 (Ootpa) with Podman, Podman Compose
+  - podman-compose version 1.5.0
+  - podman version 4.9.4-rhel
+- Amazon Linux 2023 with Docker, Docker Compose
+  - Docker version 25.0.8, build 0bab007
+  - Docker Compose version v2.13.0

--- a/podman/database-compose.yml
+++ b/podman/database-compose.yml
@@ -1,0 +1,46 @@
+# Optimized for QueryPie 11.0.x - Database Profile
+# Compatible with both Docker and Podman
+
+name: querypie
+services:
+  mysql:
+    hostname: mysql
+    networks:
+      - database-network
+    image: docker.io/querypie/mysql:8.0.42
+    volumes:
+      - mysql-data:/var/lib/mysql
+      - ./mysql_init:/docker-entrypoint-initdb.d:ro
+    ports:
+      - "3306:3306"
+    restart: unless-stopped
+    environment:
+      - MYSQL_USER=${DB_USERNAME}
+      - MYSQL_PASSWORD=${DB_PASSWORD}
+      - MYSQL_ROOT_PASSWORD=${DB_PASSWORD}
+      - MYSQL_DATABASE=${DB_CATALOG:?ex. querypie}
+
+  redis:
+    hostname: redis
+    networks:
+      - database-network
+    image: docker.io/querypie/redis:7.4.5
+    ports:
+      - "6379:6379"
+    restart: unless-stopped
+    environment:
+      - REDIS_PASSWORD=${REDIS_PASSWORD}
+    command: ["redis-server", "--requirepass", "${REDIS_PASSWORD:?REDIS_PASSWORD variable is not set}"]
+
+volumes:
+  mysql-data:
+    driver: local # By default, the size of this volume is unlimited.
+
+networks:
+  database-network:
+    name: querypie-database
+    driver: bridge
+
+x-podman:
+  # Use - for container name separator to be compatible with Docker Compose v2.
+  name_separator_compat: true


### PR DESCRIPTION
## 변경사항
- 하나의 docker-compose.yml 대신, database.yml, querypie.yml, tools.yml 등 Compose Yaml 을 세 개로 분리합니다. 
- MySQL 데이터 경로를 Container Volume 으로 제공합니다.
  - 디렉토리 경로를 Mount 하는 경우, chown 을 수행하지 못한다는 오류가 발생합니다.
- 그 외 변경사항에 대해, README.md 의 설명을 참조하여 주세요.

## 테스팅 결과
docker-compose 로 실행하기 - 초기 DB 생성, PASSWORD 적용 확인
```
[ec2-user@ip-172-31-11-201 podman]$ docker-compose -f database-compose.yml up -d
[+] Running 4/4
 ⠿ Container querypie-redis-1    Started    0.5s
 ⠿ Container querypie-mysql-1    Started   0.6s
[ec2-user@ip-172-31-11-201 podman]$ cat ~/.my.cnf
[client]
host=127.0.0.1
database=querypie
user=querypie
password=<password>
[ec2-user@ip-172-31-11-201 podman]$ mysql -e "SHOW DATABASES;"
+--------------------+
| Database           |
+--------------------+
| information_schema |
| performance_schema |
| querypie           |
| querypie_log       |
| querypie_snapshot  |
+--------------------+
[ec2-user@ip-172-31-11-201 podman]$ REDISCLI_AUTH=<wrong> valkey-cli PING
AUTH failed: WRONGPASS invalid username-password pair or user is disabled.
(error) NOAUTH Authentication required.
[ec2-user@ip-172-31-11-201 podman]$ REDISCLI_AUTH=<password> valkey-cli PING
PONG
[ec2-user@ip-172-31-11-201 podman]$ 
```

podman-compose 로 확인하기
```
[ec2-user@ip-172-31-49-179 podman]$ podman-compose -f database-compose.yml up -d
54f742c73adfcd050c4e37ee79639eeaa18ac255cf043230132a4cdf5279cf6d
f3c4d76f8a59c4e2d4d3c80eea8db897ed0cf6ad566333b20e588d3dbcde757c
fdf35171bc5105feb94f5d6d96f600d94b8f6c4ac5f786f55a0bb570b67189ce
querypie-mysql-1
querypie-redis-1
[ec2-user@ip-172-31-49-179 podman]$ docker ps
Emulate Docker CLI using podman. Create /etc/containers/nodocker to quiet msg.
CONTAINER ID  IMAGE                            COMMAND               CREATED        STATUS        PORTS                   NAMES
f3c4d76f8a59  docker.io/querypie/mysql:8.0.42  mysqld                2 seconds ago  Up 2 seconds  0.0.0.0:3306->3306/tcp  querypie-mysql-1
fdf35171bc51  docker.io/querypie/redis:7.4.5   --requirepass 287...  2 seconds ago  Up 1 second   0.0.0.0:6379->6379/tcp  querypie-redis-1
[ec2-user@ip-172-31-49-179 podman]$ mysql -e "SHOW DATABASES;"
+--------------------+
| Database           |
+--------------------+
| information_schema |
| performance_schema |
| querypie           |
| querypie_log       |
| querypie_snapshot  |
+--------------------+
[ec2-user@ip-172-31-49-179 podman]$ REDISCLI_AUTH=<password> redis-cli PING
PONG
[ec2-user@ip-172-31-49-179 podman]$ REDISCLI_AUTH=<wrong> redis-cli PING
(error) NOAUTH Authentication required.
[ec2-user@ip-172-31-49-179 podman]$ 
```
