### PR TITLE
setup.v2.sh: docker registry 명시하기

### DIFF
--- a/aws-ami/scripts/setup.v2.sh
+++ b/aws-ami/scripts/setup.v2.sh
@@ -10,7 +10,7 @@
 set -o nounset -o errexit -o errtrace -o pipefail
 
 # Version will be manually increased by the author.
-SCRIPT_VERSION="25.07.2"     # YY.MM.PATCH
+SCRIPT_VERSION="25.07.3"     # YY.MM.PATCH
 RECOMMENDED_VERSION="11.0.0" # QueryPie version to install by default.
 ASSUME_YES=false
 
@@ -190,7 +190,7 @@ function install::config_files() {
   rm package.tar.gz
   log::do sed -i.orig \
     -e "s#- \\./mysql:/var/lib/mysql#- ../mysql:/var/lib/mysql#" \
-    -e "s#harbor.chequer.io/querypie/#querypie/#" \
+    -e "s#harbor.chequer.io/querypie/#docker.io/querypie/#" \
     -e "s#source: /var/log/querypie#source: ../log#" \
     ./querypie/"$QP_VERSION"/docker-compose.yml
   rm ./querypie/"$QP_VERSION"/docker-compose.yml.orig


### PR DESCRIPTION
## 변경사항
- querypie/querypie:tag 라는 image repository:tag 에는 docker.io 라는 registry 가 명시되어 있지 않습니다.
- podman 환경 등을 고려하여, docker-compose.yml 의 image repository 에서, docker registry 를 docker.io 라고 명시합니다.