### PR TITLE
podman: podman-compose.yml 설정 구현

### DIFF
--- a/podman/README.md
+++ b/podman/README.md
@@ -10,20 +10,20 @@ Podman, Podman Compose 를 지원하는 QueryPie 실행 환경을 제공합니�
 1. `.env` 파일을 작성하기
     - `.env.template`을 복사하여, `.env` 파일을 작성하고, 필요한 환경변수 값을 설정합니다.
     - `cp .env.template .env`, `vi .env`
-2. 실행하기: `podman-compose -f database-compose.yml up -d`
-3. 종료하기: `podman-compose -f database-compose.yml down`
+2. 실행하기: `podman-compose --profile=database up -d`
+3. 종료하기: `podman-compose --profile=database down`
 
 ### Tools 를 실행하기
 
-1. 실행하기: `podman-compose -f tools-compose.yml up -d`
-2. Migration 실행하기: `podman-compose -f tools-compose.yml exec tools /app/script/migrate.sh runall`
-3. 종료하기: `podman-compose -f tools-compose.yml down`
+1. 실행하기: `podman-compose --profile=tools up -d`
+2. Migration 실행하기: `podman-compose --profile=tools exec tools /app/script/migrate.sh runall`
+3. 종료하기: `podman-compose --profile=tools down`
 
 ### QueryPie 를 실행하기
 
-1. 실행하기: `podman-compose -f querypie-compose.yml up -d`
-2. 실행성공 확인하기: `podman-compose -f querypie-compose.yml exec app readyz`
-3. 종료하기: `podman-compose -f querypie-compose.yml down`
+1. 실행하기: `podman-compose --profile=app up -d`
+2. 실행성공 확인하기: `podman-compose  --profile=app exec app readyz`
+3. 종료하기: `podman-compose --profile=app down`
 
 ## Compose Yaml 의 변경사항
 

--- a/podman/podman-compose.yml
+++ b/podman/podman-compose.yml
@@ -1,0 +1,165 @@
+# Optimized for QueryPie 11.0.x
+# Compatible with both Docker and Podman
+
+name: querypie
+services:
+  mysql:
+    profiles:
+      - database
+      - mysql
+    hostname: mysql
+    networks:
+      - database-network
+    image: docker.io/querypie/mysql:8.0.42
+    volumes:
+      - ./mysql:/var/lib/mysql
+      - ./mysql_init:/docker-entrypoint-initdb.d:ro
+    ports:
+      - "3306:3306"
+    restart: unless-stopped
+    environment:
+      - MYSQL_USER=${DB_USERNAME}
+      - MYSQL_PASSWORD=${DB_PASSWORD}
+      - MYSQL_ROOT_PASSWORD=${DB_PASSWORD}
+      - MYSQL_DATABASE=${DB_CATALOG:?ex. querypie}
+
+  redis:
+    profiles:
+      - database
+      - redis
+    hostname: redis
+    networks:
+      - database-network
+    image: docker.io/querypie/redis:7.4.5
+    ports:
+      - "6379:6379"
+    restart: unless-stopped
+    environment:
+      - REDIS_PASSWORD=${REDIS_PASSWORD}
+    command: ["redis-server", "--requirepass", "${REDIS_PASSWORD:?REDIS_PASSWORD variable is not set}"]
+
+  app:
+    profiles:
+      - app
+      - querypie
+    networks:
+      - querypie-network
+    image: docker.io/querypie/querypie:${VERSION}
+    volumes:
+      - type: bind
+        source: ../log
+        target: /var/log/querypie
+      - type: bind
+        source: ./nginx.d/ # Custom Nginx Configuration
+        target: /etc/nginx/nginx.d/ # Effective for 10.2.6 or later
+      - type: bind
+        source: ./certs/ # Custom TLS Certificates
+        target: /app/certs/
+      - type: bind
+        source: ${DAC_SKIP_SQL_COMMAND_RULE_FILE}
+        target: /app/arisa/skip_command_config.json
+    restart: always
+
+    ports:
+      # Nginx with HTTP
+      - 8000:80
+      # Nginx with HTTPS (powered by fake cert)
+      - 1443:443
+      # DAC, SAC Proxy Port
+      - 9000:9000
+      # KAC Proxy Port
+      - 6443:6443
+      # WAC Proxy Port
+      - 7447:7447
+      # DAC Agentless Proxy Port
+      # If you don't need to use the Agentless Proxy, Remove the following port forwarding.
+      - ${PROXY_PORT_START:-40000}-${PROXY_PORT_END:-40030}:${PROXY_PORT_START:-40000}-${PROXY_PORT_END:-40030}
+
+    # Handle both Docker and Podman host references
+    extra_hosts:
+      - "host.docker.internal:host-gateway" # For Docker
+      - "host.containers.internal:host-gateway" # For Podman
+
+    env_file:
+      - .env
+    environment:
+      - VERSION=${VERSION:?ex. 11.0.0} # Validate VERSION here instead of in image reference
+      - REDIS_NODES=${REDIS_NODES:?ex. redis.querypie.io:6379,redis.querypie.io:6380,redis.querypie.io:6381}
+      - REDIS_PASSWORD=${REDIS_PASSWORD}
+      - AGENT_SECRET=${AGENT_SECRET:?32 ASCII characters}
+
+      # QueryPie MetaDB
+      - DB_HOST=${DB_HOST:?ex. mysql.querypie.io}
+      - DB_PORT=${DB_PORT:?ex. 3306}
+      - DB_CATALOG=${DB_CATALOG:?ex. querypie}
+      - DB_USERNAME=${DB_USERNAME}
+      - DB_PASSWORD=${DB_PASSWORD}
+
+      # QueryPie LogDB
+      - LOG_DB_CATALOG=${LOG_DB_CATALOG:?ex. querypie_log}
+
+      # QueryPie SnapshotDB
+      - ENG_DB_CATALOG=${ENG_DB_CATALOG:?ex. querypie_snapshot}
+
+      # The Key Encryption Key (KEK) encrypts Data Encryption Key (DEK) that encrypts a sensitive data such as database connection string, ssh key, and kubeconfig in order to protect the sensitive data even if those keys are compromised.
+      # This value can initially be set to any string, but it must remain unchanged once established.
+      - KEY_ENCRYPTION_KEY=${KEY_ENCRYPTION_KEY}
+
+    # Works with both Docker and Podman
+    sysctls:
+      net.ipv4.ip_local_port_range: "10000 39999"
+
+  tools:
+    profiles:
+      - tools
+    networks:
+      - tools-network
+    image: docker.io/querypie/querypie-tools:${VERSION}
+    ports:
+      - "8050:8050"
+    # Handle both Docker and Podman host references
+    extra_hosts:
+      - "host.docker.internal:host-gateway" # For Docker
+      - "host.containers.internal:host-gateway" # For Podman
+    environment:
+      - VERSION=${VERSION:?ex. 11.0.0} # Validate VERSION here instead of in image reference
+      - DB_HOST=${DB_HOST:?ex. mysql.querypie.io}
+      - DB_PORT=${DB_PORT:?ex. 3306}
+      - DB_CATALOG=${DB_CATALOG:?ex. querypie}
+      - DB_USERNAME=${DB_USERNAME}
+      - DB_PASSWORD=${DB_PASSWORD}
+
+      - LOG_DB_HOST=${DB_HOST}
+      - LOG_DB_PORT=${DB_PORT}
+      - LOG_DB_CATALOG=${LOG_DB_CATALOG:?ex. querypie_log}
+      - LOG_DB_USERNAME=${DB_USERNAME}
+      - LOG_DB_PASSWORD=${DB_PASSWORD}
+
+      - ENG_DB_HOST=${DB_HOST}
+      - ENG_DB_PORT=${DB_PORT}
+      - ENG_DB_CATALOG=${ENG_DB_CATALOG:?ex. querypie_snapshot}
+      - ENG_DB_USERNAME=${DB_USERNAME}
+      - ENG_DB_PASSWORD=${DB_PASSWORD}
+
+      # The Key Encryption Key (KEK) encrypts the Data Encryption Key (DEK),
+      # which then encrypts sensitive data including database connection strings, SSH keys, and kubeconfig files.
+      # This two-layer encryption approach safeguards sensitive information even if the encrypted data is compromised.
+      # The KEK can be initially set to any string value, but must remain consistent after it has been established.
+      - KEK=${KEY_ENCRYPTION_KEY}
+
+networks:
+  database-network: # Internal network identifier used in service definitions
+    name: querypie_database # Actual Docker network name visible in `docker network ls`
+    driver: bridge
+
+  querypie-network:
+    name: querypie_app
+    driver: bridge
+
+  tools-network:
+    name: querypie_tools
+    driver: bridge
+
+x-podman:
+  # Use - for container name separator to be compatible with Docker Compose v2.
+  name_separator_compat: true


### PR DESCRIPTION
## 변경사항
- 기존에는 database-compose.yml, tools-compose.yml, querypie-compose.yml 등 3개 compose.yml 을 제공하였습니다.
- 이 변경에서는 podman-compose.yml 하나의 compose.yml 로 기존 3개 설정파일을 대체하는 기능을 제공합니다.
  - name 을 `querypie` 로 둡니다.
  - container_name 을 명시하지 않습니다.
  - podman-compose 를 위한 필수 변경 사항이 적용되어 있고, docker-compose 와 호환됩니다.
- README.md 를 podman-compose.yml 파일 기준으로 수정합니다.

## 테스팅 결과
- podman-compose 를 이용해 설치가 잘 됩니다.