### PR TITLE
AMI: Ubuntu 24.04 x86_64 에서 설치 기능 검증을 자동화합니다.

### DIFF
--- a/aws-ami/az2023-install.pkr.hcl
+++ b/aws-ami/az2023-install.pkr.hcl
@@ -134,7 +134,7 @@ build {
     ]
     inline = [
       "set -o xtrace",
-      "[[ -d ~/.docker ]] || mkdir -p -m 700 ~/.docker",
+      "[ -d ~/.docker ] || mkdir -p -m 700 ~/.docker",
       "sed 's/<base64-encoded-username:password>/${var.docker_auth}/g' /tmp/docker-config.tmpl.json > ~/.docker/config.json",
       "chmod 600 ~/.docker/config.json"
     ]

--- a/aws-ami/ubuntu24.04-install.pkr.hcl
+++ b/aws-ami/ubuntu24.04-install.pkr.hcl
@@ -1,0 +1,190 @@
+# This file is to create a QueryPie AMI using Packer for AWS Marketplace.
+
+packer {
+  required_plugins {
+    amazon = {
+      version = ">= 1.2.8"
+      source  = "github.com/hashicorp/amazon"
+    }
+  }
+}
+
+# Variables
+variable "querypie_version" {
+  type        = string
+  default     = "10.3.0"
+  description = "Version of QueryPie to install"
+}
+
+variable "docker_auth" {
+  type        = string
+  description = "Base64-encoded Docker registry authentication (username:password)"
+  # No default value for security reasons, must be provided at runtime
+}
+
+# Local variables
+locals {
+  timestamp = regex_replace(timestamp(), "[- TZ:]", "")
+  ami_name = "QueryPie-Suite-Installer-${local.timestamp}"
+
+  region = "ap-northeast-2"
+  instance_type = "t3.xlarge" # Use t3.xlarge to accelerate the build process
+  ssh_username = "ec2-user" # SSH username for Amazon Linux 2023
+
+  common_tags = {
+    CreatedBy = "Packer"
+    Owner     = "AZ2023-Installer"
+    Purpose   = "Automated QueryPie Installer"
+    BuildDate = local.timestamp
+    Version   = var.querypie_version
+  }
+
+  instance_tags = merge(
+    local.common_tags,
+    {
+      Name = "AZ2023-Installer-${var.querypie_version}"
+    }
+  )
+}
+
+# Data source for latest Amazon Linux 2023 AMI
+# data : Keyword to begin a data source block
+# amazon-ami : Type of data source, or plugin name
+# amazon-linux-2023 : Name of the data source
+data "amazon-ami" "amazon-linux-2023" {
+  filters = {
+    name                = "al2023-ami-*-x86_64"
+    root-device-type    = "ebs"
+    virtualization-type = "hvm"
+  }
+  most_recent = true
+  owners = ["amazon"]
+  region      = local.region
+}
+
+# Builder Configuration
+# source : Keyword to begin a source block
+# amazon-ebs : Type of builder, or plugin name
+# az2023-install : Name of the builder
+source "amazon-ebs" "az2023-install" {
+  skip_create_ami = true
+  source_ami      = data.amazon-ami.amazon-linux-2023.id
+  ami_name        = local.ami_name
+
+  region        = local.region
+  instance_type = local.instance_type
+  ssh_username = local.ssh_username
+
+  # EBS configuration
+  ebs_optimized = true
+  ena_support   = true
+  sriov_support = true
+
+  # Root volume configuration
+  launch_block_device_mappings {
+    device_name           = "/dev/xvda"
+    volume_size           = 32
+    volume_type           = "gp3"
+    iops = 16000 # Max: 16000 IOPS for gp3
+    throughput = 1000  # Max: 1000 MiB/s throughput
+    delete_on_termination = true
+    encrypted             = true
+  }
+
+  # Instance metadata options
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 1
+  }
+
+  # Security group configuration
+  temporary_security_group_source_cidrs = ["0.0.0.0/0"]
+
+  # Tags of the EC2 instance used for building the AMI
+  run_tags = local.instance_tags
+}
+
+# Build configuration
+build {
+  sources = [
+    "source.amazon-ebs.az2023-install"
+  ]
+
+  provisioner "shell" {
+    inline = [
+      "set -o xtrace",
+      "cloud-init status --wait",
+      # Now this EC2 instance is ready for more software installation.
+
+      "# Installing essential packages...",
+      "sudo dnf install -y docker",
+      "sudo usermod -aG docker ${local.ssh_username}",
+    ]
+  }
+
+  # Setup .docker/config.json for Docker registry authentication
+  provisioner "file" {
+    source      = "docker-config.tmpl.json"
+    destination = "/tmp/docker-config.tmpl.json"
+  }
+  provisioner "shell" {
+    environment_vars = [
+      "DOCKER_AUTH=${var.docker_auth}"
+    ]
+    inline = [
+      "set -o xtrace",
+      "[[ -d ~/.docker ]] || mkdir -p -m 700 ~/.docker",
+      "sed 's/<base64-encoded-username:password>/${var.docker_auth}/g' /tmp/docker-config.tmpl.json > ~/.docker/config.json",
+      "chmod 600 ~/.docker/config.json"
+    ]
+  }
+
+  # Install scripts such as setup.v2.sh
+  provisioner "file" {
+    source      = "scripts/"
+    destination = "/tmp/"
+  }
+  provisioner "shell" {
+    inline = [
+      "set -o xtrace",
+      "sudo install -m 755 /tmp/setup.v2.sh /usr/local/bin/setup.v2.sh",
+    ]
+  }
+
+  # Install QueryPie Deployment Package
+  provisioner "shell" {
+    inline = [
+      "set -o xtrace",
+      "setup.v2.sh --install ${var.querypie_version}",
+      "setup.v2.sh --verify-installation",
+    ]
+  }
+
+  # Final cleanup
+  provisioner "shell" {
+    inline = [
+      "echo '# Performing final cleanup...'",
+      "set -o xtrace",
+      "rm ~/.docker/config.json",
+      "sudo dnf clean all",
+      "sudo rm -rf /tmp/*",
+      "sudo rm -rf /var/tmp/*",
+      "history -c",
+      "cat /dev/null > ~/.bash_history",
+      "sudo rm -f /root/.bash_history",
+      "sudo find /var/log -type f -exec truncate -s 0 {} \\;",
+      "echo 'Cleanup completed'"
+    ]
+  }
+
+  # Generate manifest
+  post-processor "manifest" {
+    output     = "manifest.json"
+    strip_path = true
+    custom_data = {
+      timestmap        = local.timestamp
+      querypie_version = var.querypie_version
+    }
+  }
+}

--- a/aws-ami/ubuntu24.04-install.pkr.hcl
+++ b/aws-ami/ubuntu24.04-install.pkr.hcl
@@ -29,11 +29,11 @@ locals {
 
   region = "ap-northeast-2"
   instance_type = "t3.xlarge" # Use t3.xlarge to accelerate the build process
-  ssh_username = "ec2-user" # SSH username for Amazon Linux 2023
+  ssh_username = "ubuntu" # SSH username for Ubuntu 24.04
 
   common_tags = {
     CreatedBy = "Packer"
-    Owner     = "AZ2023-Installer"
+    Owner     = "Ubuntu24.04-Installer"
     Purpose   = "Automated QueryPie Installer"
     BuildDate = local.timestamp
     Version   = var.querypie_version
@@ -42,33 +42,35 @@ locals {
   instance_tags = merge(
     local.common_tags,
     {
-      Name = "AZ2023-Installer-${var.querypie_version}"
+      Name = "Ubuntu24.04-Installer-${var.querypie_version}"
     }
   )
 }
 
-# Data source for latest Amazon Linux 2023 AMI
+# Data source for latest Ubuntu 24.04 LTS AMI
 # data : Keyword to begin a data source block
 # amazon-ami : Type of data source, or plugin name
-# amazon-linux-2023 : Name of the data source
-data "amazon-ami" "amazon-linux-2023" {
+# ubuntu-24-04 : Name of the data source
+data "amazon-ami" "ubuntu-24-04" {
+  # For detailed information of the AMI:
+  # `aws ec2 describe-images --image-ids ami-0662f4965dfc70aca`
   filters = {
-    name                = "al2023-ami-*-x86_64"
+    name                = "ubuntu/images/*/ubuntu-noble-24.04-amd64-server-*"
     root-device-type    = "ebs"
     virtualization-type = "hvm"
   }
   most_recent = true
-  owners = ["amazon"]
+  owners = ["099720109477"] # # Canonical's AWS Account ID
   region      = local.region
 }
 
 # Builder Configuration
 # source : Keyword to begin a source block
 # amazon-ebs : Type of builder, or plugin name
-# az2023-install : Name of the builder
-source "amazon-ebs" "az2023-install" {
+# ubuntu24-04-install : Name of the builder
+source "amazon-ebs" "ubuntu24-04-install" {
   skip_create_ami = true
-  source_ami      = data.amazon-ami.amazon-linux-2023.id
+  source_ami      = data.amazon-ami.ubuntu-24-04.id
   ami_name        = local.ami_name
 
   region        = local.region
@@ -82,7 +84,8 @@ source "amazon-ebs" "az2023-install" {
 
   # Root volume configuration
   launch_block_device_mappings {
-    device_name           = "/dev/xvda"
+    # device_name is confirmed from: `aws ec2 describe-images --image-ids ami-0662f4965dfc70aca`
+    device_name           = "/dev/sda1"
     volume_size           = 32
     volume_type           = "gp3"
     iops = 16000 # Max: 16000 IOPS for gp3
@@ -108,18 +111,39 @@ source "amazon-ebs" "az2023-install" {
 # Build configuration
 build {
   sources = [
-    "source.amazon-ebs.az2023-install"
+    "source.amazon-ebs.ubuntu24-04-install"
   ]
 
   provisioner "shell" {
+    inline_shebang = "/bin/bash -ex"
     inline = [
-      "set -o xtrace",
       "cloud-init status --wait",
       # Now this EC2 instance is ready for more software installation.
-
+      "# Show the current process list and group information",
+      "ps ux", "id -Gn",
       "# Installing essential packages...",
-      "sudo dnf install -y docker",
+      "sudo apt -qq update",
+      "curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /tmp/docker.asc",
+      "sudo install -m 0755 -d /etc/apt/keyrings",
+      "sudo install -m 0644 /tmp/docker.asc /etc/apt/keyrings/docker.asc",
+      "echo 'deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu noble stable' | sudo tee /etc/apt/sources.list.d/docker.list",
+      "sudo apt -qq update",
+      "DEBIAN_FRONTEND=noninteractive sudo -E apt-get -y -qq install docker-ce docker-ce-cli containerd.io docker-compose-plugin docker-ce-rootless-extras docker-buildx-plugin docker-model-plugin",
+
+      "sudo systemctl start docker",
+      "sudo systemctl enable docker",
+
       "sudo usermod -aG docker ${local.ssh_username}",
+    ]
+  }
+
+  # Force SSH reconnection to ensure fresh session
+  provisioner "shell" {
+    inline_shebang = "/bin/bash -ex"
+    expect_disconnect = true # It will logout at the end of this provisioner.
+    inline = [
+      "echo 'Forcing SSH reconnection...'",
+      "killall sshd",
     ]
   }
 
@@ -129,12 +153,13 @@ build {
     destination = "/tmp/docker-config.tmpl.json"
   }
   provisioner "shell" {
+    inline_shebang = "/bin/bash -ex"
     environment_vars = [
       "DOCKER_AUTH=${var.docker_auth}"
     ]
     inline = [
-      "set -o xtrace",
-      "[[ -d ~/.docker ]] || mkdir -p -m 700 ~/.docker",
+      "ps ux", "id -Gn",
+      "[ -d ~/.docker ] || mkdir -p -m 700 ~/.docker",
       "sed 's/<base64-encoded-username:password>/${var.docker_auth}/g' /tmp/docker-config.tmpl.json > ~/.docker/config.json",
       "chmod 600 ~/.docker/config.json"
     ]
@@ -146,16 +171,16 @@ build {
     destination = "/tmp/"
   }
   provisioner "shell" {
+    inline_shebang = "/bin/bash -ex"
     inline = [
-      "set -o xtrace",
       "sudo install -m 755 /tmp/setup.v2.sh /usr/local/bin/setup.v2.sh",
     ]
   }
 
   # Install QueryPie Deployment Package
   provisioner "shell" {
+    inline_shebang = "/bin/bash -ex"
     inline = [
-      "set -o xtrace",
       "setup.v2.sh --install ${var.querypie_version}",
       "setup.v2.sh --verify-installation",
     ]
@@ -163,11 +188,12 @@ build {
 
   # Final cleanup
   provisioner "shell" {
+    inline_shebang = "/bin/bash -ex"
     inline = [
       "echo '# Performing final cleanup...'",
-      "set -o xtrace",
       "rm ~/.docker/config.json",
-      "sudo dnf clean all",
+      "sudo apt clean",
+      "sudo apt autoremove -y",
       "sudo rm -rf /tmp/*",
       "sudo rm -rf /var/tmp/*",
       "history -c",

--- a/aws-ami/ubuntu24.04-install.sh
+++ b/aws-ami/ubuntu24.04-install.sh
@@ -35,8 +35,8 @@ function packer::install() {
     -timestamp-ui \
     ${packer_option} \
     ubuntu24.04-install.pkr.hcl |
-    sed 's/ ==> amazon-ebs\.ubuntu24.04-install://'
-    # Remove the builder name of '==> amazon-ebs.ubuntu24.04-install:'
+    sed 's/ ==> amazon-ebs\.ubuntu24-04-install://'
+    # Remove the builder name of '==> amazon-ebs.ubuntu24-04-install:'
 }
 
 function validate_environment() {

--- a/aws-ami/ubuntu24.04-install.sh
+++ b/aws-ami/ubuntu24.04-install.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+set -o nounset -o errexit -o errtrace -o pipefail
+
+BOLD_CYAN="\e[1;36m"
+BOLD_RED="\e[1;91m"
+RESET="\e[0m"
+
+function log::do() {
+  # print ascii color code for bold cyan and reset
+  printf "%b+ %s%b\n" "$BOLD_CYAN" "$*" "$RESET" 1>&2
+  if "$@"; then
+    return 0
+  else
+    log::error "Failed to run: $*"
+    return 1
+  fi
+}
+
+function log::error() {
+  printf "%bERROR: %s%b\n" "$BOLD_RED" "$*" "$RESET" 1>&2
+}
+
+function packer::install() {
+  local version=$1 packer_option="${PACKER_OPTION:-}"
+  # NOTE(JK): Use `PACKER_OPTION=-on-error=abort` to allow debugging the AMI build process.
+  echo >&2 "### Install QueryPie and Verify with Packer ###"
+  echo >&2 "PACKER_OPTION: $packer_option"
+
+  # Disable SC2086(Use double quotes to prevent word splitting) to allow expansion of variables.
+  # shellcheck disable=SC2086
+  log::do packer build \
+    -var "querypie_version=$version" \
+    -var "docker_auth=$DOCKER_AUTH" \
+    -timestamp-ui \
+    ${packer_option} \
+    ubuntu24.04-install.pkr.hcl |
+    sed 's/ ==> amazon-ebs\.ubuntu24.04-install://'
+    # Remove the builder name of '==> amazon-ebs.ubuntu24.04-install:'
+}
+
+function validate_environment() {
+  if ! command -v packer &>/dev/null; then
+    log::error "Packer is not installed. Please install Packer to continue."
+    exit 1
+  fi
+
+  if ! command -v aws &>/dev/null; then
+    log::error "AWS CLI is not installed. Please install AWS CLI to continue."
+    exit 1
+  fi
+
+  if [[ -z "${DOCKER_AUTH:-}" ]]; then
+    log::error "DOCKER_AUTH environment variable is not set. Please set it to the base64-encoded Docker registry authentication."
+    exit 1
+  fi
+}
+
+function main() {
+  local querypie_version=${1:-} ami_name timestamp
+  if [[ -z "$querypie_version" ]]; then
+    echo "Usage: $0 <querypie_version>"
+    exit 1
+  fi
+
+  validate_environment
+
+  packer::install "$querypie_version"
+}
+
+main "$@"


### PR DESCRIPTION
## 변경사항

- Amazon Linux 2023 의 설정파일을 수정없이 복사하여, ubuntu24.04-install.sh, ubuntu24.04-install.pkr.hcl 파일을 만듭니다.
    - 이후 Ubuntu 24.04 에 맞추어 최소한의 변경을 적용합니다.
- docker 설치 후, ssh session 을 끊습니다.
    - `provisioner` 마다 개별적으로 ssh session 이 생성되지 않습니다. bash script 내부에서 실행되기에, logout 으로 ssh session 을 종료할 수 없습니다.
    - 이에 따라, sshd process 를 강제로 종료합니다.
- Use `[` instead of `[[` for more compatibility.`
- Root block device 의 이름을 정확히 알아내고, 이를 launch_block_device_mappings 에 적용합니다.
    - Root block device 의 이름을 정확히 지정하지 않으면, 새로운 block device 가 추가됩니다.
    - 기존 Root block device 의 설정값이 변경되지 않아, 기본값 8 GiB 의 작은 volume 이 만들어집니다.
- `provisioner "shell"` 블럭에서, inline_shebang 을 설정하고, `set -o xtrace` 명령을 제거합니다.
    - inline_shebang 은 `/bin/sh` 또는 `dash`가 실행되지 않고, `/bin/bash`가 실행되도록, 경로를 명시합니다.

## 테스팅 결과
```
jk@Jk-Kim-VVVY6C7KYV aws-ami % ./ubuntu24.04-install.sh 11.0.1
### Install QueryPie and Verify with Packer ###
+ packer build -var querypie_version=11.0.1 -var docker_auth=cm9ib3QkY2hlcXVlci1pbnRlcm5hbDpHN2pZeUxSc2RlWEUxTzlXWURoczMyVVhaaVpVeElsNQ== -timestamp-ui -on-error=abort ubuntu24.04-install.pkr.hcl
amazon-ebs.ubuntu24-04-install: output will be in this color.

2025-08-05T13:59:25+09:00: skip_create_ami was set; not prevalidating AMI name
2025-08-05T13:59:25+09:00: Found Image ID: ami-0ff140cadd6129869

....

2025-08-05T14:07:56+09:00: Build 'amazon-ebs.ubuntu24-04-install' finished after 8 minutes 31 seconds.

==> Wait completed after 8 minutes 31 seconds

==> Builds finished but no artifacts were created.
jk@Jk-Kim-VVVY6C7KYV aws-ami % 
```