### PR TITLE
AMI: ubuntu-22.04 amd64 에서 설치 테스트 수행

### DIFF
--- a/aws-ami/install.sh
+++ b/aws-ami/install.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+set -o nounset -o errexit -o errtrace -o pipefail
+
+BOLD_CYAN="\e[1;36m"
+BOLD_RED="\e[1;91m"
+RESET="\e[0m"
+
+function log::do() {
+  # print ascii color code for bold cyan and reset
+  printf "%b+ %s%b\n" "$BOLD_CYAN" "$*" "$RESET" 1>&2
+  if "$@"; then
+    return 0
+  else
+    log::error "Failed to run: $*"
+    return 1
+  fi
+}
+
+function log::error() {
+  printf "%bERROR: %s%b\n" "$BOLD_RED" "$*" "$RESET" 1>&2
+}
+
+function packer::install() {
+  local distro=$1 version=$2 packer_option="${PACKER_OPTION:-}"
+  # NOTE(JK): Use `PACKER_OPTION=-on-error=abort` to allow debugging the AMI build process.
+  echo >&2 "### Install QueryPie and Verify with Packer ###"
+  echo >&2 "PACKER_OPTION: $packer_option"
+
+  if [[ ! -f $distro-install.pkr.hcl ]]; then
+    log::error "No such distro available: $distro"
+    exit 1
+  fi
+
+  # Disable SC2086(Use double quotes to prevent word splitting) to allow expansion of variables.
+  # shellcheck disable=SC2086
+  log::do packer build \
+    -var "querypie_version=$version" \
+    -timestamp-ui \
+    ${packer_option} \
+    $distro-install.pkr.hcl |
+    sed 's/ ==> amazon-ebs\..*-install://'
+  # Remove the builder name of '==> amazon-ebs.ubuntu24-04-install:'
+}
+
+function validate_environment() {
+  if ! command -v packer &>/dev/null; then
+    log::error "Packer is not installed. Please install Packer to continue."
+    exit 1
+  fi
+}
+
+function main() {
+  local distro=${1:-} querypie_version=${2:-}
+  if [[ -z "${distro}" || -z "$querypie_version" ]]; then
+    cat <<END_OF_USAGE
+Usage: $0 <distro> <querypie_version>
+
+EXAMPLE:
+  $0 az2023 11.0.1
+  $0 ubuntu24.04 11.0.1
+  $0 ubuntu22.04 11.0.1
+  PACKER_OPTION=-on-error=abort $0 az2023 11.0.1
+
+END_OF_USAGE
+    exit 1
+  fi
+
+  validate_environment
+
+  packer::install "$distro" "$querypie_version"
+}
+
+main "$@"

--- a/aws-ami/scripts/install-docker-on-ubuntu.sh
+++ b/aws-ami/scripts/install-docker-on-ubuntu.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+set -o nounset -o errexit -o errtrace -o pipefail
+set -o xtrace
+
+DOWNLOAD_URL=https://download.docker.com/linux
+
+packages=(
+  docker-ce
+  docker-ce-cli # version_gte 18.09
+  containerd.io # version_gte 18.09
+  docker-compose-plugin # version_gte 20.10
+  docker-ce-rootless-extras # version_gte 20.10
+  docker-buildx-plugin # version_gte 23.0
+  docker-model-plugin # version_gte 28.2
+)
+
+function install_docker() {
+  local lsb_dist distro_version
+
+  DEBIAN_FRONTEND=noninteractive sudo -E sudo apt -qq update
+
+  curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /tmp/docker.asc
+  sudo install -m 0755 -d /etc/apt/keyrings
+  sudo install -m 0644 /tmp/docker.asc /etc/apt/keyrings/docker.asc
+
+  lsb_dist="$(. /etc/os-release && echo "$ID" | tr '[:upper:]' '[:lower:]')"
+  distro_version=$(lsb_release --codename | cut -f2)
+
+  echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] $DOWNLOAD_URL/$lsb_dist $distro_version stable" |
+    sudo tee /etc/apt/sources.list.d/docker.list
+  DEBIAN_FRONTEND=noninteractive sudo -E sudo apt -qq update
+
+  DEBIAN_FRONTEND=noninteractive sudo -E apt-get -y -qq install "${packages[@]}"
+
+  sudo systemctl start docker
+  sudo systemctl enable docker
+
+  sudo usermod -aG docker "$USER"
+}
+
+function main() {
+  install_docker
+}
+
+main "$@"

--- a/aws-ami/ubuntu24.04-install.pkr.hcl
+++ b/aws-ami/ubuntu24.04-install.pkr.hcl
@@ -111,24 +111,13 @@ build {
   provisioner "shell" {
     inline_shebang = "/bin/bash -ex"
     inline = [
-      "cloud-init status --wait",
-      # Now this EC2 instance is ready for more software installation.
-      "# Show the current process list and group information",
-      "ps ux", "id -Gn",
-      "# Installing essential packages...",
-      "sudo apt -qq update",
-      "curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /tmp/docker.asc",
-      "sudo install -m 0755 -d /etc/apt/keyrings",
-      "sudo install -m 0644 /tmp/docker.asc /etc/apt/keyrings/docker.asc",
-      "echo 'deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu noble stable' | sudo tee /etc/apt/sources.list.d/docker.list",
-      "sudo apt -qq update",
-      "DEBIAN_FRONTEND=noninteractive sudo -E apt-get -y -qq install docker-ce docker-ce-cli containerd.io docker-compose-plugin docker-ce-rootless-extras docker-buildx-plugin docker-model-plugin",
-
-      "sudo systemctl start docker",
-      "sudo systemctl enable docker",
-
-      "sudo usermod -aG docker ${local.ssh_username}",
+      "cloud-init status --wait", # Now this EC2 instance is ready for more software installation.
+      "ps ux", "id -Gn", # Show the current process list and group information
     ]
+  }
+
+  provisioner "shell" {
+    script = "scripts/install-docker-on-ubuntu.sh"
   }
 
   # Force SSH reconnection to ensure fresh session
@@ -149,6 +138,7 @@ build {
   provisioner "shell" {
     inline_shebang = "/bin/bash -ex"
     inline = [
+      "ps ux", "id -Gn", # Show the current process list and group information
       "sudo install -m 755 /tmp/setup.v2.sh /usr/local/bin/setup.v2.sh",
     ]
   }


### PR DESCRIPTION
## 변경사항
- 설치 테스트 대상이 되는 리눅스 배포본의 수가 늘어나고 있습니다. 이에 따라, Packer 스크립트 실행을 위한 wrapper shell script 를 공통으로 구현합니다: `install.sh`
- Ubuntu 에서 Docker 를 설치하는 스크립트, `install-docker-on-ubuntu.sh`를 22.04, 24.04 모두에 작동하도록 구현합니다.
- ubuntu22.04-install.pkr.hcl 를 구현합니다.
- az2023-install.pkr.hcl 에서 docker 설치를 제거합니다. 이미 docker 가 설치되어 있습니다.

## 테스팅 결과
- `./install.sh az2023 11.0.1` 성공
- `./install.sh ubuntu24.04 11.0.1` 성공
- `./install.sh ubuntu22.04 11.0.1` 실패 - tools 실행시 비밀번호 오류. TODO(JK): 추후 해결
