### PR TITLE
Install: arm64, AWS Spot Instance 적용

### DIFF
--- a/aws-ami/verify-install.sh
+++ b/aws-ami/verify-install.sh
@@ -22,7 +22,7 @@ function log::error() {
 }
 
 function packer::install() {
-  local distro=$1 version=$2 packer_option="${PACKER_OPTION:-}" packer
+  local version=$1 distro=$2 architecture=$3 packer_option="${PACKER_OPTION:-}" packer
   # NOTE(JK): Use `PACKER_OPTION=-on-error=abort` to allow debugging the AMI build process.
   echo >&2 "### Install QueryPie and Verify with Packer ###"
   echo >&2 "PACKER_OPTION: $packer_option"
@@ -37,6 +37,7 @@ function packer::install() {
   # shellcheck disable=SC2086
   log::do packer build \
     -var "querypie_version=$version" \
+    -var "architecture=${architecture}" \
     -var "resource_owner=${USER:-Unknown}" \
     -timestamp-ui \
     ${packer_option} \
@@ -53,16 +54,17 @@ function validate_environment() {
 }
 
 function main() {
-  local distro=${1:-} querypie_version=${2:-}
-  if [[ -z "${distro}" || -z "$querypie_version" ]]; then
+  local querypie_version=${1:-} distro=${2:-amazon-linux-2023} architecture=${3:-x86_64}
+  if [[ -z "$querypie_version" ]]; then
     cat <<END_OF_USAGE
-Usage: $0 <distro> <querypie_version>
+Usage: $0 <querypie_version> [<distro>] [<architecture>]
 
 EXAMPLE:
-  $0 az2023 11.0.1
-  $0 ubuntu24.04 11.0.1
-  $0 ubuntu22.04 11.0.1
-  PACKER_OPTION=-on-error=abort $0 az2023 11.0.1
+  $0 11.0.1 amazon-linux-2023
+  $0 11.0.1 amazon-linux-2023 arm64
+  $0 11.0.1 ubuntu-24.04
+  $0 11.0.1 ubuntu-22.04
+  PACKER_OPTION=-on-error=abort $0 11.0.1 amazon-linux-2023
 
 END_OF_USAGE
     exit 1
@@ -70,7 +72,7 @@ END_OF_USAGE
 
   validate_environment
 
-  packer::install "$distro" "$querypie_version"
+  packer::install "$querypie_version" "$distro" "$architecture"
 }
 
 main "$@"

--- a/aws-ami/verify-install/ubuntu-22.04.pkr.hcl
+++ b/aws-ami/verify-install/ubuntu-22.04.pkr.hcl
@@ -16,6 +16,12 @@ variable "querypie_version" {
   description = "Version of QueryPie to install"
 }
 
+variable "architecture" {
+  type = string
+  default = "x86_64"
+  description = "x86_64 | arm64"
+}
+
 variable "resource_owner" {
   type        = string
   default     = "Ubuntu22.04-Installer"
@@ -28,7 +34,6 @@ locals {
   ami_name = "QueryPie-Suite-Installer-${local.timestamp}"
 
   region = "ap-northeast-2"
-  instance_type = "t3.xlarge" # Use t3.xlarge to accelerate the build process
   ssh_username = "ubuntu" # SSH username for Ubuntu 22.04
 
   common_tags = {
@@ -51,13 +56,24 @@ locals {
 # data : Keyword to begin a data source block
 # amazon-ami : Type of data source, or plugin name
 # ubuntu-22-04 : Name of the data source
+###
+# aws ec2 describe-images --image-ids ami-08943a151bd468f4e
+# "Name": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20250516"
+# "Description": "Canonical, Ubuntu, 22.04, amd64 jammy image"
+# "Architecture": "x86_64"
+# "DeviceName": "/dev/sda1"
+###
+# aws ec2 describe-images --image-ids ami-081f3c5131ba55215
+# "Name": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20250516"
+# "Description": "Canonical, Ubuntu, 22.04, arm64 jammy image"
+# "Architecture": "arm64"
+# "DeviceName": "/dev/sda1"
 data "amazon-ami" "ubuntu-22-04" {
-  # For detailed information of the AMI:
-  # `aws ec2 describe-images --image-ids ami-08943a151bd468f4e`
   filters = {
-    name                = "ubuntu/images/*/ubuntu-jammy-22.04-amd64-server-*"
+    name                = "ubuntu/images/*/ubuntu-jammy-22.04-*-server-*"
     root-device-type    = "ebs"
     virtualization-type = "hvm"
+    architecture        = var.architecture == "arm64" ? "arm64" : "x86_64"
   }
   most_recent = true
   owners = ["099720109477"] # # Canonical's AWS Account ID
@@ -74,17 +90,21 @@ source "amazon-ebs" "ubuntu22-04-install" {
   ami_name        = local.ami_name
 
   region        = local.region
-  instance_type = local.instance_type
   ssh_username = local.ssh_username
+  # ssh_private_key_file = "demo-targets.pem"
+  # ssh_keypair_name = "demo-targets"
+
+  # spot_instance_types = ["t4g.xlarge"]
+  spot_instance_types = var.architecture == "arm64" ? ["t4g.xlarge"] : ["t3.xlarge"]
+  spot_price = "0.09" # the maximum hourly price
+  # $0.0646 for t4g.xlarge instance in ap-northeast-2
+  # $0.078 for t3.xlarge instance
 
   # EBS configuration
   ebs_optimized = true
-  ena_support   = true
-  sriov_support = true
 
   # Root volume configuration
   launch_block_device_mappings {
-    # device_name is confirmed from: `aws ec2 describe-images --image-ids ami-08943a151bd468f4e`
     device_name           = "/dev/sda1"
     volume_size           = 32
     volume_type           = "gp3"
@@ -143,7 +163,7 @@ build {
   provisioner "shell" {
     inline_shebang = "/bin/bash -ex"
     inline = [
-      "setup.v2.sh --install ${var.querypie_version}",
+      "setup.v2.sh --yes --install ${var.querypie_version}",
       "setup.v2.sh --verify-installation",
     ]
   }


### PR DESCRIPTION
## 변경사항
- AWS Spot Instance 를 적용하여, 테스트에 사용하는 AWS Resource 비용을 60% 정도 줄입니다.
- `verify-install.sh` argument 순서를 변경합니다. `verify-install.sh <querypie_version> [<distro>] [<architecture>]`
    - distro 를 입력하지 않으면, amazon-linux-2023 이 지정됩니다.
    - architecture 를 입력하지 않으면, x86_64 가 지정됩니다.
- `verify-install.sh` architecture 를 지정하는 옵션을 추가합니다. arm64 architecture 를 지정하는 경우, 그에 맞는 설치 테스트가 수행됩니다.
    - Amazon Linux 2023, Ubuntu 24.04, Ubuntu 22.04 에 적용되었습니다.
- `setup.v2.sh --yes --install <version>` 으로 `--yes` 를 지정합니다.
    - 11.0.1-beta 와 같은 예외적 버전 이름을 사용할 수 있습니다.

## 테스팅 결과
다음 설치가 정상적으로 수행됩니다.
- `./verify-install.sh 11.0.1-beta amazon-linux-2023 arm64`
- `./verify-install.sh 11.0.1-beta ubuntu-22.04 arm64`
- `./verify-install.sh 11.0.1-beta ubuntu-24.04 arm64`