### PR TITLE
AWS: RHEL8 설치 검증 자동화

### DIFF
--- a/aws/scripts/install-docker-on-rhel8.sh
+++ b/aws/scripts/install-docker-on-rhel8.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+set -o nounset -o errexit -o errtrace -o pipefail
+set -o xtrace
+
+packages=(
+  docker-ce
+  docker-ce-cli             # version_gte 18.09
+  containerd.io             # version_gte 18.09
+  docker-compose-plugin     # version_gte 20.10
+  docker-ce-rootless-extras # version_gte 20.10
+  docker-buildx-plugin      # version_gte 23.0
+  docker-model-plugin       # version_gte 28.2
+)
+
+function install_docker_and_compose() {
+  local hardware
+  hardware=$(uname -m)
+
+  sudo dnf -y -q --setopt=install_weak_deps=False install dnf-plugins-core
+  sudo rm -f /etc/yum.repos.d/docker-ce.repo /etc/yum.repos.d/docker-ce-staging.repo
+  sudo dnf config-manager --add-repo https://download.docker.com/linux/rhel/docker-ce.repo
+  sudo dnf makecache
+
+  sudo dnf -y -q --best install "${packages[@]}"
+
+  sudo systemctl start docker
+  sudo systemctl enable docker
+
+  sudo usermod -aG docker "$USER"
+}
+
+function test_if_docker_installed_already {
+  # Show the current process list and group information
+  ps ux
+  id -Gn
+  docker ps
+}
+
+function shutdown_ssh_session {
+  pkill -f sshd
+}
+
+function main() {
+  if test_if_docker_installed_already; then
+    :
+  else
+    install_docker_and_compose
+    shutdown_ssh_session
+  fi
+}
+
+main "$@"

--- a/aws/verify-install/rhel8.pkr.hcl
+++ b/aws/verify-install/rhel8.pkr.hcl
@@ -1,0 +1,197 @@
+# This file is to create a QueryPie AMI using Packer for AWS Marketplace.
+
+packer {
+  required_plugins {
+    amazon = {
+      version = ">= 1.2.8"
+      source  = "github.com/hashicorp/amazon"
+    }
+  }
+}
+
+# Variables
+variable "querypie_version" {
+  type        = string
+  default     = "10.3.0"
+  description = "Version of QueryPie to install"
+}
+
+variable "architecture" {
+  type        = string
+  default     = "x86_64"
+  description = "x86_64 | arm64"
+}
+
+variable "resource_owner" {
+  type        = string
+  default     = "RHEL8-Installer"
+  description = "Owner of AWS Resources"
+}
+
+# Local variables
+locals {
+  timestamp = regex_replace(timestamp(), "[- TZ:]", "")
+  ami_name = "QueryPie-Suite-Installer-${local.timestamp}"
+
+  region = "ap-northeast-2"
+  ssh_username = "ec2-user" # SSH username for RHEL 8
+
+  common_tags = {
+    CreatedBy = "Packer"
+    Owner     = var.resource_owner
+    Purpose   = "Automated QueryPie Installer"
+    BuildDate = local.timestamp
+    Version   = var.querypie_version
+  }
+
+  instance_tags = merge(
+    local.common_tags,
+    {
+      Name = "RHEL8-Installer-${var.querypie_version}"
+    }
+  )
+}
+
+# Data source for latest RHEL 8 AMI
+# data : Keyword to begin a data source block
+# amazon-ami : Type of data source, or plugin name
+# rhel8 : Name of the data source
+###
+# aws ec2 describe-images --image-ids ami-0aa790f1c5e7a301e
+# "Name": "RHEL-8.10.0_HVM-20250529-x86_64-1792-Hourly2-GP3"
+# "Description": "Provided by Red Hat, Inc."
+# "Architecture": "x86_64"
+# "DeviceName": "/dev/sda1"
+###
+# aws ec2 describe-images --image-ids ami-0d6118ae1d3e19b26
+# "Name": "RHEL-8.10.0_HVM-20250529-arm64-1788-Hourly2-GP3"
+# "Description": "Provided by Red Hat, Inc."
+# "Architecture": "arm64"
+# "DeviceName": "/dev/sda1"
+data "amazon-ami" "rhel8" {
+  filters = {
+    name                = "RHEL-8.*"
+    root-device-type    = "ebs"
+    virtualization-type = "hvm"
+    architecture        = var.architecture == "arm64" ? "arm64" : "x86_64"
+  }
+  most_recent = true
+  owners = ["309956199498"] # Red Hat's AWS Account ID
+  region      = local.region
+}
+
+# Builder Configuration
+# source : Keyword to begin a source block
+# amazon-ebs : Type of builder, or plugin name
+# rhel8-install : Name of the builder
+source "amazon-ebs" "rhel8-install" {
+  skip_create_ami = true
+  source_ami      = data.amazon-ami.rhel8.id
+  ami_name        = local.ami_name
+
+  region               = local.region
+  ssh_username         = local.ssh_username
+  # ssh_private_key_file = "demo-targets.pem"
+  # ssh_keypair_name = "demo-targets"
+
+  # spot_instance_types = ["t4g.xlarge"]
+  spot_instance_types = var.architecture == "arm64" ? ["t4g.xlarge"] : ["t3.xlarge"]
+  spot_price          = "0.16" # the maximum hourly price
+  # + $0.08 for software cost
+  # $0.0646 for t4g.xlarge instance in ap-northeast-2
+  # $0.078 for t3.xlarge instance
+
+  # EBS configuration
+  ebs_optimized = true
+
+  # Root volume configuration
+  launch_block_device_mappings {
+    device_name           = "/dev/sda1"
+    volume_size           = 32
+    volume_type           = "gp3"
+    iops = 16000 # Max: 16000 IOPS for gp3
+    throughput = 1000  # Max: 1000 MiB/s throughput
+    delete_on_termination = true
+    encrypted             = true
+  }
+
+  # Instance metadata options
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 1
+  }
+
+  # Security group configuration
+  temporary_security_group_source_cidrs = ["0.0.0.0/0"]
+
+  # Tags of the EC2 instance used for building the AMI
+  run_tags = local.instance_tags
+}
+
+# Build configuration
+build {
+  sources = [
+    "source.amazon-ebs.rhel8-install"
+  ]
+
+  provisioner "shell" {
+    inline_shebang = "/bin/bash -ex"
+    inline = [
+      "cloud-init status --wait", # Now this EC2 instance is ready for more software installation.
+    ]
+  }
+
+  provisioner "shell" {
+    expect_disconnect = true # It will logout at the end of this provisioner.
+    script = "../scripts/install-docker-on-rhel8.sh"
+  }
+
+  # Install scripts such as setup.v2.sh
+  provisioner "file" {
+    source      = "../scripts/"
+    destination = "/tmp/"
+  }
+  provisioner "shell" {
+    inline_shebang = "/bin/bash -ex"
+    inline = [
+      "ps ux", "id -Gn", # Show the current process list and group information
+      "sudo install -m 755 /tmp/setup.v2.sh /usr/local/bin/setup.v2.sh",
+    ]
+  }
+
+  # Install QueryPie Deployment Package
+  provisioner "shell" {
+    inline_shebang = "/bin/bash -ex"
+    inline = [
+      "setup.v2.sh --yes --install ${var.querypie_version}",
+      "setup.v2.sh --verify-installation",
+    ]
+  }
+
+  # Final cleanup
+  provisioner "shell" {
+    inline_shebang = "/bin/bash -ex"
+    inline = [
+      "echo '# Performing final cleanup...'",
+      "sudo dnf clean all",
+      "sudo rm -rf /tmp/*",
+      "sudo rm -rf /var/tmp/*",
+      "history -c",
+      "cat /dev/null > ~/.bash_history",
+      "sudo rm -f /root/.bash_history",
+      "sudo find /var/log -type f -exec truncate -s 0 {} \\;",
+      "echo 'Cleanup completed'"
+    ]
+  }
+
+  # Generate manifest
+  post-processor "manifest" {
+    output     = "manifest.json"
+    strip_path = true
+    custom_data = {
+      timestmap        = local.timestamp
+      querypie_version = var.querypie_version
+    }
+  }
+}


### PR DESCRIPTION
## 변경사항
- aws/scripts/install-docker-on-rhel8.sh 를 구현합니다.
  - `killall sshd` 대신 `pkill -f sshd`을 사용하여야, sshd process 가 종료됩니다.
- rhel8.pkr.hcl 를 작성합니다.
  - Spot Instance Price 를 다른 경우보다 높게 설정합니다. Software 가격이 포함되어 있기 때문입니다. Fix install-docker-on-rhel8.sh
- 설치 과정에서, SELinux 설정 변경이 필요합니다.

## 테스팅 결과
`./verify-install.sh 11.1.1 rhel8 x86_64` - 성공
`./verify-install.sh 11.1.1 rhel8 arm64` - 성공

## SELinux 설정 변경
```
2025-08-21T15:32:49+09:00: #
2025-08-21T15:32:49+09:00: ## Verify SELinux settings
2025-08-21T15:32:49+09:00: #
2025-08-21T15:32:49+09:00: # SELinux is installed on this system.
2025-08-21T15:32:49+09:00: # SELinux is enabled on this system.
2025-08-21T15:32:49+09:00: # The current mode of SELinux is enforcing.
2025-08-21T15:32:49+09:00: ## You may need to change the SELinux context of the ./querypie directory.
2025-08-21T15:32:49+09:00: # A more permissive SELinux context (container_file_t) is required for ./querypie.
2025-08-21T15:32:49+09:00: + ls -dZ ./querypie
2025-08-21T15:32:49+09:00: # The following sudo command is recommended:
2025-08-21T15:32:49+09:00: unconfined_u:object_r:user_home_t:s0 ./querypie
2025-08-21T15:32:49+09:00: #   sudo chcon -Rt container_file_t ./querypie
2025-08-21T15:32:49+09:00: # Without this change, you may encounter container errors.
2025-08-21T15:32:49+09:00: Do you want to run the above sudo chcon -Rt container_file_t ./querypie command?
2025-08-21T15:32:49+09:00: + sudo chcon -Rt container_file_t ./querypie
2025-08-21T15:32:49+09:00: Do you agree? [y/N] : yes
2025-08-21T15:32:49+09:00: ~/querypie/11.1.1 ~
```