### PR TITLE
setup.v2.sh: Docker Compose 를 Docker Plugin 으로 사용합니다

### DIFF
--- a/compose/local-reset.sh
+++ b/compose/local-reset.sh
@@ -16,5 +16,5 @@ for container in querypie-app-1 querypie-tools-1 querypie-mysql-1 querypie-redis
   $DOCKER rm $container || true
 done
 
-sudo rm -rf ~/querypie/mysql
+sudo rm -rf ~/querypie/mysql ~/querypie/log
 rm -rf ~/querypie/*


### PR DESCRIPTION
## 변경사항
- SCRIPT_VERSION="25.08.4"
- 기존 Docker Compose 사용방식은, `/usr/local/bin/docker-compose` 명령을 직접 호출하였습니다.
- 변경된 방식은, `docker compose` 방식으로 Compose Tool 을 Docker Plugin 형태로 사용합니다. 더이상 `docker-compose` 실행파일을 직접 실행하지 않습니다.
- 이에 따라, setup.v2.sh 의 몇몇 함수를 재작성합니다.
    - `verify::docker_installation` 함수를 `verify::container_engine_installation` 로 이름을 바꾸고 수정합니다.
    - `install::docker_compose` 함수를 재작성합니다. 특히, docker-compose 실행파일을 `~/.docker/cli-plugins/docker-compose` 에 설치합니다.
    - `command_exists` 함수를 `command::whereis` 로 재작성합니다.
- `~/.docker/cli-plugins/docker-compose`에 설치된 Compose Tool 은 Podman 에서도 `podman compose` 라고 호출하여 곧바로 사용할 수 있습니다.
    - 이에 따라, 이용자에게 `podman-compose`를 미리 설치할 것을 요구하지 않습니다. `podman` 은 `dnf` 명령으로 쉽게 설치가 되지만, `podman-compose` 는 pip 로 설치해야 하기에, python3 upgrade, pip repository 접근 등 의존성이 크게 요구됩니다.
- Fix local-reset.sh

## 테스팅 결과
- 여러 OS 에서 설치를 할 수 있습니다.
- Podman Rootless Docker Mode 로 곧바로 설치가 가능합니다.
