### PR TITLE
setup.v2.sh: RHEL8 에서 Podman 을 기본 설치합니다.

### DIFF
--- a/aws/verify-install/amazon-linux-2023.pkr.hcl
+++ b/aws/verify-install/amazon-linux-2023.pkr.hcl
@@ -17,8 +17,8 @@ variable "querypie_version" {
 }
 
 variable "architecture" {
-  type = string
-  default = "x86_64"
+  type        = string
+  default     = "x86_64"
   description = "x86_64 | arm64"
 }
 
@@ -104,7 +104,7 @@ source "amazon-ebs" "amazon-linux-2023" {
 
   # spot_instance_types = ["t4g.xlarge"]
   spot_instance_types = var.architecture == "arm64" ? ["t4g.xlarge"] : ["t3.xlarge"]
-  spot_price = "0.09" # the maximum hourly price
+  spot_price          = "0.09" # the maximum hourly price
   # $0.0646 for t4g.xlarge instance in ap-northeast-2
   # $0.078 for t3.xlarge instance
 
@@ -159,9 +159,9 @@ build {
     expect_disconnect = true # It will logout at the end of this provisioner.
     inline_shebang = "/bin/bash -ex"
     inline = [
-      var.container_engine == "docker" ? "/tmp/install-docker-on-amazon-linux-2023.sh" : "true",
-      var.container_engine == "podman" ? "/tmp/podman_unavailable.sh" : "true",
-      var.container_engine == "none" ? "/tmp/setup.v2.sh --container-engine-only" : "true",
+        var.container_engine == "docker" ? "/tmp/install-docker-on-amazon-linux-2023.sh" : "true",
+        var.container_engine == "podman" ? "/tmp/podman_unavailable.sh" : "true",
+        var.container_engine == "none" ? "/tmp/setup.v2.sh --container-engine-only" : "true",
     ]
   }
 
@@ -182,7 +182,7 @@ build {
   provisioner "shell" {
     inline_shebang = "/bin/bash -ex"
     inline = [
-      "setup.v2.sh --yes --install ${var.querypie_version}",
+      "setup.v2.sh --yes --universal --install ${var.querypie_version}",
       "setup.v2.sh --verify-installation",
     ]
   }

--- a/aws/verify-install/rhel8.pkr.hcl
+++ b/aws/verify-install/rhel8.pkr.hcl
@@ -24,8 +24,10 @@ variable "architecture" {
 
 variable "container_engine" {
   type        = string
-  default     = "docker"
-  description = "docker | podman"
+  default     = "none"
+  description = "docker | podman | none"
+  # If container_engine is set to none, Packer script will not install a container engine.
+  # setup.v2.sh will install Docker or Podman.
 }
 
 variable "resource_owner" {
@@ -148,9 +150,20 @@ build {
     ]
   }
 
+  # Install scripts such as setup.v2.sh
+  provisioner "file" {
+    source      = "../scripts/"
+    destination = "/tmp/"
+  }
+
   provisioner "shell" {
     expect_disconnect = true # It will logout at the end of this provisioner.
-    script = var.container_engine == "podman" ? "../scripts/install-podman-on-rhel8.sh" : "../scripts/install-docker-on-rhel8.sh"
+    inline_shebang = "/bin/bash -ex"
+    inline = [
+        var.container_engine == "docker" ? "/tmp/install-docker-on-rhel8.sh" : "true",
+        var.container_engine == "podman" ? "/tmp/install-podman-on-rhel8.sh" : "true",
+        var.container_engine == "none" ? "/tmp/setup.v2.sh --container-engine-only" : "true",
+    ]
   }
 
   # Install scripts such as setup.v2.sh


### PR DESCRIPTION
## 변경사항
- setup.v2.sh 는 RHEL8 에서 Docker 대신 Podman 을 기본 설치하도록 변경합니다.
    - 이후, Rootless Mode, Podman 운영 환경을 검증하는데 활용합니다.

## 테스팅 결과
- `./verify-install.sh 11.1.1 rhel8 x86_64 none`: 성공
- 다음은 RHEL8 에서 Podman 설치 때, 함께 설치되는 패키지의 내역, 상세한 설치 과정입니다.
```
2025-08-22T15:16:49+09:00: + sudo dnf -y -q --best install podman podman-plugins podman-manpages
2025-08-22T15:18:43+09:00:
2025-08-22T15:18:43+09:00: Installed:
2025-08-22T15:18:43+09:00:   conmon-3:2.1.10-1.module+el8.10.0+23320+f7205097.x86_64
2025-08-22T15:18:43+09:00:   container-selinux-2:2.229.0-2.module+el8.10.0+23320+f7205097.noarch
2025-08-22T15:18:43+09:00:   containernetworking-plugins-1:1.4.0-6.module+el8.10.0+23320+f7205097.x86_64
2025-08-22T15:18:43+09:00:   containers-common-2:1-82.module+el8.10.0+23320+f7205097.x86_64
2025-08-22T15:18:43+09:00:   criu-3.18-5.module+el8.10.0+23320+f7205097.x86_64
2025-08-22T15:18:43+09:00:   dnsmasq-2.79-33.el8_10.x86_64
2025-08-22T15:18:43+09:00:   fuse-common-3.3.0-19.el8.x86_64
2025-08-22T15:18:43+09:00:   fuse-overlayfs-1.13-1.module+el8.10.0+23320+f7205097.x86_64
2025-08-22T15:18:43+09:00:   fuse3-3.3.0-19.el8.x86_64
2025-08-22T15:18:43+09:00:   fuse3-libs-3.3.0-19.el8.x86_64
2025-08-22T15:18:43+09:00:   iptables-1.8.5-11.el8_9.x86_64
2025-08-22T15:18:43+09:00:   iptables-libs-1.8.5-11.el8_9.x86_64
2025-08-22T15:18:43+09:00:   libibverbs-48.0-1.el8.x86_64
2025-08-22T15:18:43+09:00:   libnet-1.1.6-15.el8.x86_64
2025-08-22T15:18:43+09:00:   libnetfilter_conntrack-1.0.6-5.el8.x86_64
2025-08-22T15:18:43+09:00:   libnfnetlink-1.0.1-13.el8.x86_64
2025-08-22T15:18:43+09:00:   libnftnl-1.2.2-3.el8.x86_64
2025-08-22T15:18:43+09:00:   libpcap-14:1.9.1-5.el8.x86_64
2025-08-22T15:18:43+09:00:   libslirp-4.4.0-2.module+el8.10.0+23320+f7205097.x86_64
2025-08-22T15:18:43+09:00:   nftables-1:1.0.4-7.el8_10.x86_64
2025-08-22T15:18:43+09:00:   podman-4:4.9.4-22.module+el8.10.0+23320+f7205097.x86_64
2025-08-22T15:18:43+09:00:   podman-catatonit-4:4.9.4-22.module+el8.10.0+23320+f7205097.x86_64
2025-08-22T15:18:43+09:00:   podman-gvproxy-4:4.9.4-22.module+el8.10.0+23320+f7205097.x86_64
2025-08-22T15:18:43+09:00:   podman-plugins-4:4.9.4-22.module+el8.10.0+23320+f7205097.x86_64
2025-08-22T15:18:43+09:00:   protobuf-c-1.3.0-8.el8.x86_64
2025-08-22T15:18:43+09:00:   runc-1:1.1.12-6.module+el8.10.0+23320+f7205097.x86_64
2025-08-22T15:18:43+09:00:   shadow-utils-subid-2:4.6-22.el8.x86_64
2025-08-22T15:18:43+09:00:   slirp4netns-1.2.3-1.module+el8.10.0+23320+f7205097.x86_64
2025-08-22T15:18:43+09:00:
2025-08-22T15:18:43+09:00: + systemctl --user enable --now podman.socket
2025-08-22T15:18:43+09:00: Created symlink /home/ec2-user/.config/systemd/user/sockets.target.wants/podman.socket → /usr/lib/systemd/user/podman.socket.
2025-08-22T15:18:43+09:00: # Podman is successfully installed at /usr/bin/podman
2025-08-22T15:18:43+09:00: # The system has a container engine already.
```