### PR TITLE
Compose: Universal Compose Package 를 개선합니다.

### DIFF
--- a/compose/universal/README.ja.md
+++ b/compose/universal/README.ja.md
@@ -1,31 +1,55 @@
-# Podman Compose と Docker Compose のための QueryPie 実行環境
+# Podman と Docker をサポートするユニバーサル実行環境
 
-Version of compose.yml: 25.07.2
-最終更新日: 2025年7月30日
+Version of compose.yml: 25.08.1
+最終更新日: 2025年8月23日
 
-このリポジトリは、Podman と Podman Compose をサポートする QueryPie 実行環境を提供します。
-また、代替として Docker と Docker Compose を使用できる互換性設定も含まれています。
-以下のガイドでは、Podman と Podman Compose を使用して QueryPie を実行する方法について説明します。
+QueryPie はコンテナ方式で配布されるアプリケーションであり、コンテナエンジンとして Docker と Podman をサポートしています。
+このディレクトリのファイルは、Compose ツールを使用して QueryPie を実行および運用するための設定ファイルです。
+
+Linux ディストリビューションによって、Podman と Docker Compose の組み合わせ、または Docker と Docker Compose の組み合わせを使用することをお勧めします。
+
+## Podman をサポートする Linux ディストリビューション
+
+以下の Linux ディストリビューションでは、Podman と Docker Compose の組み合わせを使用することをお勧めします：
+
+- Red Hat Enterprise Linux 8+
+- Rocky Linux 8+
+- CentOS 8+
+
+### 今後サポート予定の Linux ディストリビューション
+
+以下の Linux ディストリビューションでは、Podman と Docker Compose の組み合わせを検証できていません。
+Docker と Docker Compose の組み合わせを使用することをお勧めします：
+
+- Amazon Linux 2, Amazon Linux 2023
+- Ubuntu 22.04 LTS, 24.04 LTS
+
+## Podman と Docker Compose のインストール
+
+`setup.v2.sh` を使用すると、Linux サーバーに Podman と Docker Compose を自動的にインストールできます。
+QueryPie をインストールするために setup.v2.sh を実行するだけで十分です。
 
 ## QueryPie を自動的にインストールして実行する
 
-「Podman と Podman Compose のインストール方法」セクションを参照して、まず podman と podman-compose をインストールしてください。
+まず、サポートされている Linux ディストリビューションをインストールした Linux サーバーを準備します。
 
-Linux サーバーのシェルで次のコマンドを実行します。`--universal` オプションを省略してはいけないことに注意してください。
+Linux サーバーのシェルで次のコマンドを実行します：
 ```shell
-$ bash <(curl -s https://dl.querypie.com/setup.v2.sh) --universal
+$ bash <(curl -s https://dl.querypie.com/setup.v2.sh)
 ```
 または、次の方法を使用することもできます：
 ```shell
 $ curl -s https://dl.querypie.com/setup.v2.sh -o setup.v2.sh
-$ bash setup.v2.sh --universal
+$ bash setup.v2.sh
 ```
 
 `setup.v2.sh` を使用したインストールの詳細なガイドについては、次のドキュメントを参照してください：
 [Installation Guide - setup.v2.sh (JA)](https://querypie.atlassian.net/wiki/spaces/QCP/pages/1177387032/Installation+Guide+-+setup.v2.sh+JA)
 
 
-## QueryPie を手動で実行する
+## Podman で QueryPie を手動で実行する
+
+Podman は Docker と互換性のある方法で使用できます。ほとんどの Docker コマンドが Podman でサポートされています。
 
 ### MySQL と Redis の実行
 
@@ -33,89 +57,47 @@ $ bash setup.v2.sh --universal
    - `.env.template` をコピーして `.env` ファイルを作成し、必要な環境変数の値を設定します。
    - コマンド: `cp .env.template .env`、次に `vi .env`
    - 注意: `setup.v2.sh` スクリプトを使用すると、この手順は自動的に実行されます。
-2. サービスの開始: `podman-compose --profile=database up -d`
-3. サービスの停止: `podman-compose --profile=database down`
+2. サービスの開始: `podman compose --profile=database up -d`
+3. サービスの停止: `podman compose --profile=database down`
 
-### ツールの実行
+### QueryPie ツールの実行
 
-1. ツールの開始: `podman-compose --profile=tools up -d`
-2. マイグレーションの実行: `podman-compose --profile=tools exec tools /app/script/migrate.sh runall`
-3. ツールの停止: `podman-compose --profile=tools down`
+1. ツールの開始: `podman compose --profile=tools up -d`
+2. マイグレーションの実行: `podman compose --profile=tools exec tools /app/script/migrate.sh runall`
+3. ツールの停止: `podman compose --profile=tools down`
 
 ### QueryPie アプリケーションの実行
 
-1. アプリケーションの開始: `podman-compose --profile=app up -d`
-2. 正常な実行の確認: `podman-compose --profile=app exec app readyz`
-3. アプリケーションの停止: `podman-compose --profile=app down`
+1. アプリケーションの開始: `podman compose --profile=app up -d`
+2. 正常な実行の確認: `podman compose --profile=app exec app readyz`
+3. アプリケーションの停止: `podman compose --profile=app down`
 
-## Compose YAML の変更点
+## Docker で QueryPie を手動で実行する
 
-Podman Compose と Docker Compose 間の互換性を確保するために、以下の変更が行われています:
+### MySQL と Redis の実行
 
-- コンテナ名を指定する際に、区切り文字として `_` の代わりに `-` を使用するように設定を追加しました。
-  - Podman Compose はデフォルトの区切り文字として `_` を使用します。Docker Compose v2 と互換性を持たせるには、`-` を使用する必要があります。
-  - `x-podman: name_separator_compat: true` の設定を追加しました。
-  - 注意: Docker Compose v1 は区切り文字として `_` を使用し、v2 は `-` を使用します。
-- Docker イメージレジストリとして `docker.io/` レジストリを使用するように指定しました。
-  - レジストリが指定されていない場合、イメージをダウンロードする際に Podman Compose は RHEL レジストリを使用するかどうかを選択するプロンプトを表示します。
+1. `.env` ファイルの作成
+   - `.env.template` をコピーして `.env` ファイルを作成し、必要な環境変数の値を設定します。
+   - コマンド: `cp .env.template .env`、次に `vi .env`
+   - 注意: `setup.v2.sh` スクリプトを使用すると、この手順は自動的に実行されます。
+2. サービスの開始: `docker compose --profile=database up -d`
+3. サービスの停止: `docker compose --profile=database down`
 
-## Podman と Podman Compose のインストール方法
+### QueryPie ツールの実行
 
-多くの Linux ディストリビューションでは、Podman と Podman Compose をディストリビューションパッケージとして提供しています。
-ただし、Amazon Linux 2023 はデフォルトで Podman インストールパッケージを含んでいません。
+1. ツールの開始: `docker compose --profile=tools up -d`
+2. マイグレーションの実行: `docker compose --profile=tools exec tools /app/script/migrate.sh runall`
+3. ツールの停止: `docker compose --profile=tools down`
 
-### RHEL8 でのインストール
+### QueryPie アプリケーションの実行
 
-- Podman のインストール:
-  - `sudo dnf install podman`
-- Podman Compose のインストール:
-  - `sudo dnf install -y python3.11 python3.11-pip python3.11-devel`
-  - `python3.11 -m pip install --user podman-compose`
-- インストールの確認:
-  - `podman --version`
-    - バージョン 4.9.4-rhel 以降であることを確認してください。
-  - `python3.11 --version`
-  - `podman-compose --version`
-    - バージョン 1.5.0 以降であることを確認してください。
+1. アプリケーションの開始: `docker compose --profile=app up -d`
+2. 正常な実行の確認: `docker compose --profile=app exec app readyz`
+3. アプリケーションの停止: `docker compose --profile=app down`
 
-## SELinux 設定の変更
+## 技術サポートのお問い合わせ
 
-SELinux は Red Hat Enterprise Linux 8.9 (Ootpa) ではデフォルトで有効になっています。
-Podman Compose を正常に使用するには、以下のように SELinux 設定を変更する必要があります:
-
-- コンテナボリュームのマウントを許可するように SELinux 設定を変更:
-  - `cd podman`
-  - `sudo chcon -Rt container_file_t .`
-  - `sudo chcon -Rt container_file_t ../log`
-- コンテナボリュームマウントターゲットの SELinux コンテキストを確認:
-  - `cd podman`
-  - `ls -dlZ * ../log`
-  - `unconfined_u:object_r:container_file_t:s0` や `system_u:object_r:container_file_t:s0` のようなコンテキストが表示されるはずです。
-  - `user_home_t` が表示される場合、コンテナボリュームマウントを許可しない SELinux 設定を示しています。
-
-```shell
-[ec2-user@ip-172-31-49-179 podman]$ ls -adlZ * ../log
-drwxrwxrwx. 2 ec2-user ec2-user unconfined_u:object_r:container_file_t:s0     6 Jul 17 04:11 ../log
--rw-rw-r--. 1 ec2-user ec2-user unconfined_u:object_r:container_file_t:s0  3501 Jul 17 04:14 README.md
-drwxrwxr-x. 2 ec2-user ec2-user unconfined_u:object_r:container_file_t:s0    22 Jul 13 09:52 certs
--rw-rw-r--. 1 ec2-user ec2-user unconfined_u:object_r:container_file_t:s0  1278 Jul 17 03:57 database-compose.yml
--rw-rw-r--. 1 ec2-user ec2-user unconfined_u:object_r:container_file_t:s0 10368 Jul 13 10:48 docker-compose.yml
-drwxr-xr-x. 2 ec2-user ec2-user system_u:object_r:container_file_t:s0        22 Jul 13 06:35 mysql_init
-drwxrwxr-x. 2 ec2-user ec2-user unconfined_u:object_r:container_file_t:s0    38 Jul 13 09:52 nginx.d
--rw-rw-r--. 1 ec2-user ec2-user unconfined_u:object_r:container_file_t:s0  2800 Jul 17 04:23 querypie-compose.yml
--rw-rw-r--. 1 ec2-user ec2-user unconfined_u:object_r:container_file_t:s0     4 Jul 13 06:35 skip_command_config.json
--rw-rw-r--. 1 ec2-user ec2-user unconfined_u:object_r:container_file_t:s0   670 Jul 13 06:35 skip_command_config.json.example
--rw-rw-r--. 1 ec2-user ec2-user unconfined_u:object_r:container_file_t:s0  1850 Jul 13 11:43 tools-compose.yml
-[ec2-user@ip-172-31-49-179 podman]$ 
-```
-
-## テスト環境
-
-この構成は以下の環境でテストされています:
-
-- Red Hat Enterprise Linux release 8.9 (Ootpa) と Podman および Podman Compose:
-  - podman-compose バージョン 1.5.0
-  - podman バージョン 4.9.4-rhel
-- Amazon Linux 2023 と Docker および Docker Compose:
-  - Docker バージョン 25.0.8, ビルド 0bab007
-  - Docker Compose バージョン v2.13.0
+- Community Edition ユーザー：
+  [QueryPie 公式 Discord チャンネル](https://discord.gg/Cu39M55gMk)に参加して、他のユーザーと質問や情報を共有することができます。
+- Enterprise Edition ユーザー：
+  技術サポートを担当するパートナーにお問い合わせください。

--- a/compose/universal/README.ko.md
+++ b/compose/universal/README.ko.md
@@ -1,31 +1,55 @@
-# Podman Compose 및 Docker Compose를 위한 QueryPie 실행 환경
+# Podman, Docker 를 지원하는 Universal 실행 환경
 
-Version of compose.yml: 25.07.2
-최종 업데이트: 2025년 7월 30일
+Version of compose.yml: 25.08.1
+최종 업데이트: 2025년 8월 23일
 
-이 저장소는 Podman 및 Podman Compose를 지원하는 QueryPie 실행 환경을 제공합니다.
-또한 Docker 및 Docker Compose를 대안으로 사용할 수 있는 호환성 설정도 포함되어 있습니다.
-다음 가이드는 Podman 및 Podman Compose를 사용하여 QueryPie를 실행하는 방법에 대한 지침을 제공합니다.
+QueryPie 는 Container 방식으로 배포되는 애플리케이션이며, Container Engine 으로 Docker 와 Podman 을 지원합니다.
+이 디렉토리의 파일은 QueryPie 를 Compose Tool 을 이용해 실행하고 운영하기 위한 설정파일입니다.
+
+리눅스 배포본에 따라, Podman 과 Docker Compose 의 조합, 또는 Docker 와 Docker Compose 의 조합으로 사용하는 것을 권장합니다.
+
+## Podman 을 지원하는 리눅스 배포본
+
+다음의 리눅스 배포본에서는, Podman 과 Docker Compose 의 조합으로 사용하는 것을 권장합니다.
+
+- Red Hat Enterprise Linux 8+
+- Rocky Linux 8+
+- CentOS 8+
+
+### 추후 지원 예정인 리눅스 배포본
+
+다음의 리눅스 배포본에서는, Podman 과 Docker Compose 의 조합을 검증하지 못하였습니다.
+Docker 와 Docker Compose 의 조합을 사용하는 것을 권장합니다.
+
+- Amazon Linux 2, Amazon Linux 2023
+- Ubuntu 22.04 LTS, 24.04 LTS
+
+## Podman 과 Docker Compose 설치하기
+
+`setup.v2.sh` 를 이용하면, 리눅스 서버에 Podman, Docker Compose 를 자동으로 설치할 수 있습니다.
+QueryPie 를 설치하기 위한 setup.v2.sh 를 실행하는 것으로 충분합니다.
 
 ## QueryPie 를 자동으로 설치하고 실행하기
 
-"Podman 및 Podman Compose 설치 방법" 섹션을 참고하여, podman, podman-compose 를 먼저 설치하여 주세요.
+먼저, 지원하는 리눅스 배포본을 설치한 리눅스 서버를 준비합니다.
 
-리눅스 서버의 shell 에서 다음 명령을 실행합니다. `--universal` 옵션을 빠뜨리지 않아야 한다는 것에 주의하여 주세요.
+리눅스 서버의 shell 에서 다음 명령을 실행합니다.
 ```shell
-$ bash <(curl -s https://dl.querypie.com/setup.v2.sh) --universal
+$ bash <(curl -s https://dl.querypie.com/setup.v2.sh)
 ```
 또는 다음의 방법을 사용하여도 됩니다.
 ```shell
 $ curl -s https://dl.querypie.com/setup.v2.sh -o setup.v2.sh
-$ bash setup.v2.sh --universal
+$ bash setup.v2.sh
 ```
 
 `setup.v2.sh`를 이용한 설치 방법에 대한 상세한 가이드는 다음 문서를 참조하세요:
 [Installation Guide - setup.v2.sh (KO)](https://querypie.atlassian.net/wiki/spaces/QCP/pages/1177321474/Installation+Guide+-+setup.v2.sh+KO)
 
 
-## QueryPie 수작업 실행하기
+## Podman 으로 QueryPie 수작업 실행하기
+
+Podman 은 Docker 와 호환되는 방식으로 사용할 수 있습니다. 대부분의 Docker 명령이 Podman 에서 지원됩니다.
 
 ### MySQL 및 Redis 실행하기
 
@@ -33,89 +57,47 @@ $ bash setup.v2.sh --universal
    - `.env.template`를 복사하여 `.env` 파일을 생성하고 필요한 환경 변수 값을 설정합니다.
    - 명령어: `cp .env.template .env`, 그리고 `vi .env`
    - 참고: `setup.v2.sh` 스크립트를 사용하면 이 단계가 자동으로 수행됩니다.
-2. 서비스 시작: `podman-compose --profile=database up -d`
-3. 서비스 중지: `podman-compose --profile=database down`
+2. 서비스 시작: `podman compose --profile=database up -d`
+3. 서비스 중지: `podman compose --profile=database down`
 
-### 도구 실행하기
+### QueryPie Tools 실행하기
 
-1. 도구 시작: `podman-compose --profile=tools up -d`
-2. 마이그레이션 실행: `podman-compose --profile=tools exec tools /app/script/migrate.sh runall`
-3. 도구 중지: `podman-compose --profile=tools down`
+1. Tools 시작: `podman compose --profile=tools up -d`
+2. Migration 실행: `podman compose --profile=tools exec tools /app/script/migrate.sh runall`
+3. Tools 중지: `podman compose --profile=tools down`
 
-### QueryPie 애플리케이션 실행하기
+### QueryPie Application 실행하기
 
-1. 애플리케이션 시작: `podman-compose --profile=app up -d`
-2. 성공적인 실행 확인: `podman-compose --profile=app exec app readyz`
-3. 애플리케이션 중지: `podman-compose --profile=app down`
+1. Application 시작: `podman compose --profile=app up -d`
+2. 성공적인 실행 확인: `podman compose --profile=app exec app readyz`
+3. Application 중지: `podman compose --profile=app down`
 
-## Compose YAML 변경 사항
+## Docker 로 QueryPie 수작업 실행하기
 
-Podman Compose와 Docker Compose 간의 호환성을 보장하기 위해 다음과 같은 변경 사항이 적용되었습니다:
+### MySQL 및 Redis 실행하기
 
-- 컨테이너 이름을 지정할 때 구분자로 `_` 대신 `-`를 사용하도록 설정을 추가했습니다.
-  - Podman Compose는 기본 구분자로 `_`를 사용합니다. Docker Compose v2와 호환되려면 `-`를 사용해야 합니다.
-  - `x-podman: name_separator_compat: true` 설정을 추가했습니다.
-  - 참고: Docker Compose v1은 구분자로 `_`를 사용하고, v2는 `-`를 사용합니다.
-- Docker 이미지 레지스트리를 `docker.io/` 레지스트리를 사용하도록 지정했습니다.
-  - 레지스트리가 지정되지 않으면, 이미지를 다운로드할 때 Podman Compose가 RHEL 레지스트리를 사용할지 여부를 선택하라는 메시지를 표시합니다.
+1. `.env` 파일 생성하기
+    - `.env.template`를 복사하여 `.env` 파일을 생성하고 필요한 환경 변수 값을 설정합니다.
+    - 명령어: `cp .env.template .env`, 그리고 `vi .env`
+    - 참고: `setup.v2.sh` 스크립트를 사용하면 이 단계가 자동으로 수행됩니다.
+2. 서비스 시작: `docker compose --profile=database up -d`
+3. 서비스 중지: `docker compose --profile=database down`
 
-## Podman 및 Podman Compose 설치 방법
+### QueryPie Tools 실행하기
 
-많은 Linux 배포판에서 Podman 및 Podman Compose를 배포 패키지로 제공합니다.
-그러나 Amazon Linux 2023은 기본적으로 Podman 설치 패키지를 포함하지 않습니다.
+1. Tools 시작: `docker compose --profile=tools up -d`
+2. Migration 실행: `docker compose --profile=tools exec tools /app/script/migrate.sh runall`
+3. Tools 중지: `docker compose --profile=tools down`
 
-### RHEL8 에서 설치하는 방법
+### QueryPie Application 실행하기
 
-- Podman 설치:
-  - `sudo dnf install podman`
-- Podman Compose 설치:
-  - `sudo dnf install -y python3.11 python3.11-pip python3.11-devel`
-  - `python3.11 -m pip install --user podman-compose`
-- 설치 확인:
-  - `podman --version`
-    - 버전이 4.9.4-rhel 이상인지 확인하세요.
-  - `python3.11 --version`
-  - `podman-compose --version`
-    - 버전이 1.5.0 이상인지 확인하세요.
+1. Application 시작: `docker compose --profile=app up -d`
+2. 성공적인 실행 확인: `docker compose --profile=app exec app readyz`
+3. Application 중지: `docker compose --profile=app down`
 
-## SELinux 구성 변경
+## 기술지원 문의
 
-SELinux는 Red Hat Enterprise Linux 8.9 (Ootpa)에서 기본적으로 활성화되어 있습니다.
-Podman Compose를 성공적으로 사용하려면 다음과 같이 SELinux 설정을 수정해야 합니다:
-
-- 컨테이너 볼륨 마운팅을 허용하도록 SELinux 설정 변경:
-  - `cd podman`
-  - `sudo chcon -Rt container_file_t .`
-  - `sudo chcon -Rt container_file_t ../log`
-- 컨테이너 볼륨 마운팅 대상의 SELinux 컨텍스트 확인:
-  - `cd podman`
-  - `ls -dlZ * ../log`
-  - `unconfined_u:object_r:container_file_t:s0` 또는 `system_u:object_r:container_file_t:s0`와 같은 컨텍스트가 표시되어야 합니다.
-  - `user_home_t`가 표시되면 컨테이너 볼륨 마운팅을 허용하지 않는 SELinux 설정을 나타냅니다.
-
-```shell
-[ec2-user@ip-172-31-49-179 podman]$ ls -adlZ * ../log
-drwxrwxrwx. 2 ec2-user ec2-user unconfined_u:object_r:container_file_t:s0     6 Jul 17 04:11 ../log
--rw-rw-r--. 1 ec2-user ec2-user unconfined_u:object_r:container_file_t:s0  3501 Jul 17 04:14 README.md
-drwxrwxr-x. 2 ec2-user ec2-user unconfined_u:object_r:container_file_t:s0    22 Jul 13 09:52 certs
--rw-rw-r--. 1 ec2-user ec2-user unconfined_u:object_r:container_file_t:s0  1278 Jul 17 03:57 database-compose.yml
--rw-rw-r--. 1 ec2-user ec2-user unconfined_u:object_r:container_file_t:s0 10368 Jul 13 10:48 docker-compose.yml
-drwxr-xr-x. 2 ec2-user ec2-user system_u:object_r:container_file_t:s0        22 Jul 13 06:35 mysql_init
-drwxrwxr-x. 2 ec2-user ec2-user unconfined_u:object_r:container_file_t:s0    38 Jul 13 09:52 nginx.d
--rw-rw-r--. 1 ec2-user ec2-user unconfined_u:object_r:container_file_t:s0  2800 Jul 17 04:23 querypie-compose.yml
--rw-rw-r--. 1 ec2-user ec2-user unconfined_u:object_r:container_file_t:s0     4 Jul 13 06:35 skip_command_config.json
--rw-rw-r--. 1 ec2-user ec2-user unconfined_u:object_r:container_file_t:s0   670 Jul 13 06:35 skip_command_config.json.example
--rw-rw-r--. 1 ec2-user ec2-user unconfined_u:object_r:container_file_t:s0  1850 Jul 13 11:43 tools-compose.yml
-[ec2-user@ip-172-31-49-179 podman]$ 
-```
-
-## 테스트 환경
-
-이 구성은 다음 환경에서 테스트되었습니다:
-
-- Red Hat Enterprise Linux release 8.9 (Ootpa)와 Podman 및 Podman Compose:
-  - podman-compose 버전 1.5.0
-  - podman 버전 4.9.4-rhel
-- Amazon Linux 2023과 Docker 및 Docker Compose:
-  - Docker 버전 25.0.8, 빌드 0bab007
-  - Docker Compose 버전 v2.13.0
+- Community Edition 이용자:
+    [QueryPie 공식 디스코드 채널](https://discord.gg/Cu39M55gMk)에서 자유롭게 사용자 간 Q&A와 정보 공유를 할 수 있으니 많은 참여 부탁드립니다.
+- Enterprise Edition 이용자:
+    기술지원을 담당하는 파트너에게 문의 부탁드립니다.

--- a/compose/universal/README.md
+++ b/compose/universal/README.md
@@ -1,121 +1,103 @@
-# QueryPie Execution Environment for both Podman Compose and Docker Compose
+# Universal Execution Environment Supporting Podman and Docker
 
-Version of compose.yml: 25.07.2
-Last updated: July 30, 2025
+Version of compose.yml: 25.08.1
+Last updated: August 23, 2025
 
-This repository provides a QueryPie execution environment that supports both Podman and Podman Compose.
-It also includes compatibility settings that allow Docker and Docker Compose to be used as alternatives.
-The following guide provides instructions on how to run QueryPie using Podman and Podman Compose.
+QueryPie is an application deployed in Container format, supporting both Docker and Podman as Container Engines.
+The files in this directory are configuration files for running and operating QueryPie using Compose Tool.
+
+Depending on your Linux distribution, it is recommended to use either a combination of Podman and Docker Compose, or Docker and Docker Compose.
+
+## Linux Distributions Supporting Podman
+
+For the following Linux distributions, it is recommended to use a combination of Podman and Docker Compose:
+
+- Red Hat Enterprise Linux 8+
+- Rocky Linux 8+
+- CentOS 8+
+
+### Linux Distributions Planned for Future Support
+
+For the following Linux distributions, we have not yet verified the combination of Podman and Docker Compose.
+It is recommended to use a combination of Docker and Docker Compose:
+
+- Amazon Linux 2, Amazon Linux 2023
+- Ubuntu 22.04 LTS, 24.04 LTS
+
+## Installing Podman and Docker Compose
+
+You can automatically install Podman and Docker Compose on your Linux server using `setup.v2.sh`.
+Running setup.v2.sh to install QueryPie is sufficient.
 
 ## Automatically Install and Run QueryPie
 
-Please refer to the "Installation Methods for Podman and Podman Compose" section to install podman and podman-compose first.
+First, prepare a Linux server with a supported Linux distribution installed.
 
-Run the following command in the shell of your Linux server. Note that you must not omit the `--universal` option.
+Run the following command in the shell of your Linux server:
 ```shell
-$ bash <(curl -s https://dl.querypie.com/setup.v2.sh) --universal
+$ bash <(curl -s https://dl.querypie.com/setup.v2.sh)
 ```
 Or you can use the following method:
 ```shell
 $ curl -s https://dl.querypie.com/setup.v2.sh -o setup.v2.sh
-$ bash setup.v2.sh --universal
+$ bash setup.v2.sh
 ```
 
 For detailed guidance on installation using `setup.v2.sh`, please refer to the following document:
 [Installation Guide - setup.v2.sh (EN)](https://querypie.atlassian.net/wiki/spaces/QCP/pages/1176404033/Installation+Guide+-+setup.v2.sh+EN)
 
 
-## Manually Running QueryPie
+## Manually Running QueryPie with Podman
+
+Podman can be used in a way that is compatible with Docker. Most Docker commands are supported in Podman.
 
 ### Running MySQL and Redis
 
 1. Create a `.env` file
-  - Copy `.env.template` to create a `.env` file and set the necessary environment variable values.
-  - Commands: `cp .env.template .env`, then `vi .env`
-  - Note: Using the `setup.v2.sh` script will perform this step automatically.
-2. Start services: `podman-compose --profile=database up -d`
-3. Stop services: `podman-compose --profile=database down`
+   - Copy `.env.template` to create a `.env` file and set the necessary environment variable values.
+   - Commands: `cp .env.template .env`, then `vi .env`
+   - Note: Using the `setup.v2.sh` script will perform this step automatically.
+2. Start services: `podman compose --profile=database up -d`
+3. Stop services: `podman compose --profile=database down`
 
-### Running Tools
+### Running QueryPie Tools
 
-1. Start tools: `podman-compose --profile=tools up -d`
-2. Run migration: `podman-compose --profile=tools exec tools /app/script/migrate.sh runall`
-3. Stop tools: `podman-compose --profile=tools down`
+1. Start tools: `podman compose --profile=tools up -d`
+2. Run migration: `podman compose --profile=tools exec tools /app/script/migrate.sh runall`
+3. Stop tools: `podman compose --profile=tools down`
 
 ### Running QueryPie Application
 
-1. Start application: `podman-compose --profile=app up -d`
-2. Verify successful execution: `podman-compose --profile=app exec app readyz`
-3. Stop application: `podman-compose --profile=app down`
+1. Start application: `podman compose --profile=app up -d`
+2. Verify successful execution: `podman compose --profile=app exec app readyz`
+3. Stop application: `podman compose --profile=app down`
 
-## Changes to Compose YAML
+## Manually Running QueryPie with Docker
 
-The following changes have been made to ensure compatibility between Podman Compose and Docker Compose:
+### Running MySQL and Redis
 
-- Added settings to use `-` instead of `_` as the separator when specifying container names.
-  - Podman Compose uses `_` as the default separator. To be compatible with Docker Compose v2, `-` should be used.
-  - Added the setting `x-podman: name_separator_compat: true`.
-  - Note: Docker Compose v1 uses `_` as a separator, while v2 uses `-`.
-- Specified the Docker Image Registry to use the `docker.io/` Registry.
-  - If the Registry is not specified, Podman Compose will prompt you to choose whether to use the RHEL Registry when downloading images.
+1. Create a `.env` file
+   - Copy `.env.template` to create a `.env` file and set the necessary environment variable values.
+   - Commands: `cp .env.template .env`, then `vi .env`
+   - Note: Using the `setup.v2.sh` script will perform this step automatically.
+2. Start services: `docker compose --profile=database up -d`
+3. Stop services: `docker compose --profile=database down`
 
-## Installation Methods for Podman and Podman Compose
+### Running QueryPie Tools
 
-Many Linux distributions provide Podman and Podman Compose as distribution packages.
-However, Amazon Linux 2023 does not include Podman installation packages by default.
+1. Start tools: `docker compose --profile=tools up -d`
+2. Run migration: `docker compose --profile=tools exec tools /app/script/migrate.sh runall`
+3. Stop tools: `docker compose --profile=tools down`
 
-### Installation on RHEL8
+### Running QueryPie Application
 
-- Podman Installation:
-  - `sudo dnf install podman`
-- Podman Compose Installation:
-  - `sudo dnf install -y python3.11 python3.11-pip python3.11-devel`
-  - `python3.11 -m pip install --user podman-compose`
-- Verifying Installation:
-  - `podman --version`
-    - Ensure that it is version 4.9.4-rhel or later.
-  - `python3.11 --version`
-  - `podman-compose --version`
-    - Ensure that it is version 1.5.0 or later.
+1. Start application: `docker compose --profile=app up -d`
+2. Verify successful execution: `docker compose --profile=app exec app readyz`
+3. Stop application: `docker compose --profile=app down`
 
-## SELinux Configuration Changes
+## Technical Support
 
-SELinux is enabled by default on Red Hat Enterprise Linux 8.9 (Ootpa).
-To use Podman Compose successfully, you need to modify the SELinux settings as follows:
-
-- Change SELinux settings to allow Container Volume Mounting:
-  - `cd podman`
-  - `sudo chcon -Rt container_file_t .`
-  - `sudo chcon -Rt container_file_t ../log`
-- Verify the SELinux context of the Container Volume Mounting target:
-  - `cd podman`
-  - `ls -dlZ * ../log`
-  - You should see contexts like `unconfined_u:object_r:container_file_t:s0` or `system_u:object_r:container_file_t:s0`.
-  - If `user_home_t` is displayed, it indicates a SELinux setting that does not permit Container Volume Mounting.
-
-```shell
-[ec2-user@ip-172-31-49-179 podman]$ ls -adlZ * ../log
-drwxrwxrwx. 2 ec2-user ec2-user unconfined_u:object_r:container_file_t:s0     6 Jul 17 04:11 ../log
--rw-rw-r--. 1 ec2-user ec2-user unconfined_u:object_r:container_file_t:s0  3501 Jul 17 04:14 README.md
-drwxrwxr-x. 2 ec2-user ec2-user unconfined_u:object_r:container_file_t:s0    22 Jul 13 09:52 certs
--rw-rw-r--. 1 ec2-user ec2-user unconfined_u:object_r:container_file_t:s0  1278 Jul 17 03:57 database-compose.yml
--rw-rw-r--. 1 ec2-user ec2-user unconfined_u:object_r:container_file_t:s0 10368 Jul 13 10:48 docker-compose.yml
-drwxr-xr-x. 2 ec2-user ec2-user system_u:object_r:container_file_t:s0        22 Jul 13 06:35 mysql_init
-drwxrwxr-x. 2 ec2-user ec2-user unconfined_u:object_r:container_file_t:s0    38 Jul 13 09:52 nginx.d
--rw-rw-r--. 1 ec2-user ec2-user unconfined_u:object_r:container_file_t:s0  2800 Jul 17 04:23 querypie-compose.yml
--rw-rw-r--. 1 ec2-user ec2-user unconfined_u:object_r:container_file_t:s0     4 Jul 13 06:35 skip_command_config.json
--rw-rw-r--. 1 ec2-user ec2-user unconfined_u:object_r:container_file_t:s0   670 Jul 13 06:35 skip_command_config.json.example
--rw-rw-r--. 1 ec2-user ec2-user unconfined_u:object_r:container_file_t:s0  1850 Jul 13 11:43 tools-compose.yml
-[ec2-user@ip-172-31-49-179 podman]$ 
-```
-
-## Test Environment
-
-This configuration has been tested on the following environments:
-
-- Red Hat Enterprise Linux release 8.9 (Ootpa) with Podman and Podman Compose:
-  - podman-compose version 1.5.0
-  - podman version 4.9.4-rhel
-- Amazon Linux 2023 with Docker and Docker Compose:
-  - Docker version 25.0.8, build 0bab007
-  - Docker Compose version v2.13.0
+- Community Edition Users:
+  Join our community on the [Official QueryPie Discord Channel](https://discord.gg/Cu39M55gMk) to ask questions and share insights with other users.
+- Enterprise Edition Users:
+  Please contact the partner responsible for technical support.

--- a/compose/universal/compose.yml
+++ b/compose/universal/compose.yml
@@ -13,7 +13,7 @@ services:
       - database-network
     image: docker.io/querypie/mysql:8.0.42
     volumes:
-      - ./mysql:/var/lib/mysql
+      - ../mysql:/var/lib/mysql
       - ./mysql_init:/docker-entrypoint-initdb.d:ro
     ports:
       - "3306:3306"


### PR DESCRIPTION
## 변경사항

- Podman Compose 대신, Podman + Docker Compose 조합으로 사용하는 권장합니다.
- `setup.v2.sh`에서 Podman 을 자동으로 설치하기에, Podman, Podman Compose 설치 방법을 별도로 안내하지 않습니다.
- `compose.yml` 에서 mysql data dir 의 경로를 변경합니다.
  - `./mysql`이 아닌 `../mysql`을 사용하도록, 변경합니다. 이에 따라, `setup.sh`를 이용하여 Universal Compose Package 를 설치하더라도, `../mysql` 경로를 mysql data dir 로 사용하게 됩니다.
- README.ko.md 를 원본으로 문서를 작성하고, README.md, README.ja.md 를 기계 번역합니다.