### PR TITLE
setup.v2.sh: CentOS Stream 9 에서 Podman 을 기본 설치합니다.

### DIFF
--- a/aws/scripts/setup.v2.sh
+++ b/aws/scripts/setup.v2.sh
@@ -228,13 +228,18 @@ function install::docker_or_podman() {
       DOCKER=podman
       ;;
     *)
-      log::sudo amazon-linux-extras install -y docker
-      DOCKER=docker
+      log::sudo dnf -y -q --best install podman podman-plugins podman-manpages
+      DOCKER=podman
       ;;
     esac
     ;;
   rocky)
     # ID_LIKE="rhel centos fedora" - Rocky Linux 8
+    log::sudo dnf -y -q --best install podman podman-plugins podman-manpages
+    DOCKER=podman
+    ;;
+  centos)
+    # ID_LIKE=rhel fedora - CentOS Stream 9
     log::sudo dnf -y -q --best install podman podman-plugins podman-manpages
     DOCKER=podman
     ;;

--- a/aws/verify-install/centos9.pkr.hcl
+++ b/aws/verify-install/centos9.pkr.hcl
@@ -1,0 +1,218 @@
+# This file is to create a QueryPie AMI using Packer for AWS Marketplace.
+
+packer {
+  required_plugins {
+    amazon = {
+      version = ">= 1.2.8"
+      source  = "github.com/hashicorp/amazon"
+    }
+  }
+}
+
+# Variables
+variable "querypie_version" {
+  type        = string
+  default     = "10.3.0"
+  description = "Version of QueryPie to install"
+}
+
+variable "architecture" {
+  type        = string
+  default     = "x86_64"
+  description = "x86_64 | arm64"
+}
+
+variable "container_engine" {
+  type        = string
+  default     = "none"
+  description = "docker | podman | none"
+  # If container_engine is set to none, Packer script will not install a container engine.
+  # setup.v2.sh will install Docker or Podman.
+}
+
+variable "resource_owner" {
+  type        = string
+  default     = "CentOS9-Installer"
+  description = "Owner of AWS Resources"
+}
+
+# Local variables
+locals {
+  timestamp = regex_replace(timestamp(), "[- TZ:]", "")
+  ami_name = "QueryPie-Suite-Installer-${local.timestamp}"
+
+  region = "ap-northeast-2"
+  ssh_username = "ec2-user" # SSH username for CentOS 9
+
+  common_tags = {
+    CreatedBy = "Packer"
+    Owner     = var.resource_owner
+    Purpose   = "Automated QueryPie Installer"
+    BuildDate = local.timestamp
+    Version   = var.querypie_version
+  }
+
+  instance_tags = merge(
+    local.common_tags,
+    {
+      Name = "CentOS9-Installer-${var.querypie_version}"
+    }
+  )
+}
+
+# Data source for latest CentOS 9 AMI
+# data : Keyword to begin a data source block
+# amazon-ami : Type of data source, or plugin name
+# centos9 : Name of the data source
+###
+# aws ec2 describe-images --image-ids ami-02c8be0f0dff2a7c8
+# "Name": "CentOS Stream 9 x86_64 20250818"
+# "Description": "CentOS Stream 9 x86_64 20250818"
+# "Architecture": "x86_64"
+# "DeviceName": "/dev/sda1"
+###
+# aws ec2 describe-images --image-ids ami-0025c9a101a22812b
+# "Name": "CentOS Stream 9 aarch64 20250818"
+# "Description": "CentOS Stream 9 aarch64 20250818"
+# "Architecture": "arm64"
+# "DeviceName": "/dev/sda1"
+data "amazon-ami" "centos9" {
+  filters = {
+    name                = "CentOS Stream 9 *"
+    root-device-type    = "ebs"
+    virtualization-type = "hvm"
+    architecture        = var.architecture == "arm64" ? "arm64" : "x86_64"
+  }
+  most_recent = true
+  owners = ["125523088429"] # CentOS AWS Account ID
+  region      = local.region
+}
+
+# Builder Configuration
+# source : Keyword to begin a source block
+# amazon-ebs : Type of builder, or plugin name
+# centos9-install : Name of the builder
+source "amazon-ebs" "centos9-install" {
+  skip_create_ami = true
+  source_ami      = data.amazon-ami.centos9.id
+  ami_name        = local.ami_name
+
+  region               = local.region
+  ssh_username         = local.ssh_username
+  # ssh_private_key_file = "demo-targets.pem"
+  # ssh_keypair_name = "demo-targets"
+
+  # spot_instance_types = ["t4g.xlarge"]
+  spot_instance_types = var.architecture == "arm64" ? ["t4g.xlarge"] : ["t3.xlarge"]
+  spot_price          = "0.16" # the maximum hourly price
+  # + $0.08 for software cost
+  # $0.0646 for t4g.xlarge instance in ap-northeast-2
+  # $0.078 for t3.xlarge instance
+
+  # EBS configuration
+  ebs_optimized = true
+
+  # Root volume configuration
+  launch_block_device_mappings {
+    device_name           = "/dev/sda1"
+    volume_size           = 32
+    volume_type           = "gp3"
+    iops = 16000 # Max: 16000 IOPS for gp3
+    throughput = 1000  # Max: 1000 MiB/s throughput
+    delete_on_termination = true
+    encrypted             = true
+  }
+
+  # Instance metadata options
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 1
+  }
+
+  # Security group configuration
+  temporary_security_group_source_cidrs = ["0.0.0.0/0"]
+
+  # Tags of the EC2 instance used for building the AMI
+  run_tags = local.instance_tags
+}
+
+# Build configuration
+build {
+  sources = [
+    "source.amazon-ebs.centos9-install"
+  ]
+
+  provisioner "shell" {
+    inline_shebang = "/bin/bash -ex"
+    inline = [
+      "cloud-init status --wait", # Now this EC2 instance is ready for more software installation.
+      "df -h",
+    ]
+  }
+
+  # Install scripts such as setup.v2.sh
+  provisioner "file" {
+    source      = "../scripts/"
+    destination = "/tmp/"
+  }
+
+  provisioner "shell" {
+    expect_disconnect = true # It will logout at the end of this provisioner.
+    inline_shebang = "/bin/bash -ex"
+    inline = [
+        # CentOS 9 can use the same installation scripts as RHEL 8
+        var.container_engine == "docker" ? "/tmp/install-docker-on-rhel8.sh" : "true",
+        var.container_engine == "podman" ? "/tmp/install-podman-on-rhel8.sh" : "true",
+        var.container_engine == "none" ? "/tmp/setup.v2.sh --container-engine-only" : "true",
+    ]
+  }
+
+  # Install scripts such as setup.v2.sh
+  provisioner "file" {
+    source      = "../scripts/"
+    destination = "/tmp/"
+  }
+  provisioner "shell" {
+    inline_shebang = "/bin/bash -ex"
+    inline = [
+      "ps ux", "id -Gn", # Show the current process list and group information
+      "sudo install -m 755 /tmp/setup.v2.sh /usr/local/bin/setup.v2.sh",
+    ]
+  }
+
+  # Install QueryPie Deployment Package
+  provisioner "shell" {
+    inline_shebang = "/bin/bash -ex"
+    inline = [
+      "setup.v2.sh --yes --universal --install ${var.querypie_version}",
+      "setup.v2.sh --verify-installation",
+    ]
+  }
+
+  # Final cleanup
+  provisioner "shell" {
+    inline_shebang = "/bin/bash -ex"
+    inline = [
+      "echo '# Performing final cleanup...'",
+      "sudo dnf clean all",
+      "sudo rm -rf /tmp/*",
+      "sudo rm -rf /var/tmp/*",
+      "history -c",
+      "cat /dev/null > ~/.bash_history",
+      "sudo rm -f /root/.bash_history",
+      "sudo find /var/log -type f -exec truncate -s 0 {} \\;",
+      "echo 'Cleanup completed'"
+    ]
+  }
+
+  # Generate manifest
+  post-processor "manifest" {
+    output     = "manifest.json"
+    strip_path = true
+    custom_data = {
+      timestmap        = local.timestamp
+      querypie_version = var.querypie_version
+    }
+  }
+}


### PR DESCRIPTION
## 변경사항
- setup.v2.sh Container Engine 을 설치할 때, Podman 을 기본 설치합니다.
  - CentOS Stream 9 에서 제공되는 /etc/os-release 의 변수값을 확인합니다.
  - ID=centos 의 경우, Podman 을 기본 설치하도록 설정합니다.
- 설치 검증 자동화를 위해, centos9.pkr.hcl 파일을 작성합니다. CentOS Stream 9 을 설치합니다.
  - CentOS 8 또는 CentOS Stream 8 은 더이상 AWS Marketplace 에서 제공되지 않습니다.
  - us-west-2 region 에서 제공되는 AMI 가 있기는 하나, ap-northeast-2 에서는 제공되지 않습니다.
  - CentOS 8 은 AWS Marketplace 에서 Officially 제공되지 않는 것으로 간주합니다.
- ami-ls.sh 를 개선합니다.
  - AMI 생성일 최신순으로 정렬합니다.
  - CentOS 를 제공하는 AWS Marketplace 의 Cloud Platform Engineering (CPE) 계정은 125523088429 라고 알려져 있습니다. 출처: ChatGPT

## 테스팅 결과
- `./verify-install.sh 11.1.1 centos9 arm64 none`: 성공
- `./verify-install.sh 11.1.1 centos9 x86_64 none`: 성공