### PR TITLE
setup.v2.sh: Podman 설치 때, podman-docker 패키지를 함께 설치합니다.

### DIFF
--- a/aws/scripts/install-podman-on-rhel8.sh
+++ b/aws/scripts/install-podman-on-rhel8.sh
@@ -7,6 +7,8 @@ packages=(
   podman
   podman-plugins
   podman-manpages
+  # podman-docker will not be installed intentionally, to verify that setup.v2.sh works well without it.
+  # However, when setup.v2.sh installs Podman by itself, podman-docker will be installed for compatible user experience with Docker.
 )
 
 function install_podman() {

--- a/aws/scripts/setup.v2.sh
+++ b/aws/scripts/setup.v2.sh
@@ -8,7 +8,7 @@
 # $ bash setup.v2.sh --upgrade <version>
 
 # The version will be manually increased by the author.
-SCRIPT_VERSION="25.08.4" # YY.MM.PATCH
+SCRIPT_VERSION="25.08.5" # YY.MM.PATCH
 echo -n "#### QueryPie Installer ${SCRIPT_VERSION}, " >&2
 echo -n "${BASH:-}${ZSH_NAME:-} ${BASH_VERSION:-}${ZSH_VERSION:-}" >&2
 echo >&2 " on $(uname -s) $(uname -m) ####"
@@ -224,23 +224,23 @@ function install::docker_or_podman() {
   rhel)
     case "$lsb_id_like" in
     fedora) # Red Hat Enterprise Linux 8, Red Hat Enterprise Linux 9
-      log::sudo dnf -y -q --best install podman podman-plugins podman-manpages
+      log::sudo dnf -y -q --best install podman podman-plugins podman-manpages podman-docker
       DOCKER=podman
       ;;
     *)
-      log::sudo dnf -y -q --best install podman podman-plugins podman-manpages
+      log::sudo dnf -y -q --best install podman podman-plugins podman-manpages podman-docker
       DOCKER=podman
       ;;
     esac
     ;;
   rocky)
     # ID_LIKE="rhel centos fedora" - Rocky Linux 8
-    log::sudo dnf -y -q --best install podman podman-plugins podman-manpages
+    log::sudo dnf -y -q --best install podman podman-plugins podman-manpages podman-docker
     DOCKER=podman
     ;;
   centos)
     # ID_LIKE=rhel fedora - CentOS Stream 9
-    log::sudo dnf -y -q --best install podman podman-plugins podman-manpages
+    log::sudo dnf -y -q --best install podman podman-plugins podman-manpages podman-docker
     DOCKER=podman
     ;;
   *)


### PR DESCRIPTION
## 변경사항
- SCRIPT_VERSION="25.08.5"
- setup.v2.sh 는 RHEL 계열의 배포본에서 Podman 을 기본 설치하도록, 기능을 변경하였습니다.
- 이때, `podman-docker` 패키지를 함께 설치하여, `docker`와 동일한 명령어로 실행/운영할 수 있도록, 설치 환경을 구성합니다.
- 이용자에게, Docker 대신 Podman 을 기본 설치한다고 안내하더라도, 실제 사용하는 명령어는 Docker 와 동일한 경험을 제공합니다.
  - 앞으로도, Podman 설치시, podman-docker 패키지를 함께 설치하는 것을 관습으로 유지합니다.
- 이용자가 Podman 을 별도로 사전 설치하는 경우, `podman-docker` 패키지를 필수로 요구하지 않습니다. `podman` 명령이 발견되는 경우, `podman`으로 컨테이너를 관리합니다.
