### PR TITLE
offline-package.sh: Container Image 저장 기능 구현

### DIFF
--- a/compose/offline-package.sh
+++ b/compose/offline-package.sh
@@ -1,32 +1,133 @@
 #!/usr/bin/env bash
-set -o nounset -o errexit -o xtrace
+set -o nounset -o errexit -o errtrace -o pipefail
 
 # Offline Package Archive Script
 # This script packages the contents of compose/universal into compose/offline/package.tar.gz for closed network installation
 # and downloads docker-compose binaries for both x86_64 and aarch64 architectures.
 
 SCRIPT_DIR=$(dirname "$(realpath "${BASH_SOURCE[0]}")")
-OFFLINE_DIR=$(realpath "$SCRIPT_DIR/offline")
+DOCKER=docker
+
+# Color definitions
+readonly BOLD_CYAN="\e[1;36m"
+readonly BOLD_YELLOW="\e[1;33m"
+readonly BOLD_RED="\e[1;91m"
+readonly RESET="\e[0m"
+
+# Logging functions
+function log::do() {
+  printf "%b+ %s%b\n" "$BOLD_CYAN" "$*" "$RESET" 1>&2
+  if "$@"; then
+    return 0
+  else
+    log::error "Failed to run: $*"
+    return 1
+  fi
+}
+
+function log::warning() {
+  printf "%bWARNING: %s%b\n" "$BOLD_YELLOW" "$*" "$RESET" 1>&2
+}
+
+function log::error() {
+  printf "%bERROR: %s%b\n" "$BOLD_RED" "$*" "$RESET" 1>&2
+}
 
 function archive_package() {
-  pushd "universal"
-  [[ -f ${OFFLINE_DIR}/package.tar.gz ]] && rm -f "${OFFLINE_DIR}"/package.tar.gz
-  tar zcvf "${OFFLINE_DIR}"/package.tar.gz .
+  local compose_yml=$1 compose_dir
+  echo >&2 "## Creating offline/package.tar.gz from $compose_yml"
+  compose_dir=$(dirname "$compose_yml")
+  pushd "$compose_dir"
+  [[ -f ../offline/package.tar.gz ]] && rm -f ../offline/package.tar.gz
+  log::do tar zcvf ../offline/package.tar.gz .
   popd
 }
 
 function save_docker_compose() {
+  echo >&2 "## Downloading docker-compose binaries for x86_64 and aarch64"
   local kernel=linux hardware
   for hardware in x86_64 aarch64; do
-    curl -fsSL "https://dl.querypie.com/releases/bin/v2.39.1/docker-compose-${kernel}-${hardware}" -o offline/docker-compose-${kernel}-${hardware}
+    log::do curl -fsSL "https://dl.querypie.com/releases/bin/v2.39.1/docker-compose-${kernel}-${hardware}" -o offline/docker-compose-${kernel}-${hardware}
   done
 }
 
-function main() {
-  pushd "$SCRIPT_DIR"
+function detect_container_engine() {
+  echo >&2 "## Detecting Docker or Podman"
+  if log::do docker --version | grep "^Docker version"; then
+    DOCKER=docker
+    if $DOCKER ps >/dev/null 2>&1; then
+      echo >&2 "# Docker is already running and functional."
+      return
+    fi
+  elif log::do podman --version | grep "^podman version"; then
+    DOCKER=podman
+    if $DOCKER ps >/dev/null 2>&1; then
+      echo >&2 "# Podman is already running and functional."
+      return
+    fi
+  fi
+  log::error "Neither Docker nor Podman is installed or functional. Please install one of them to proceed."
+  exit 1
+}
 
-  archive_package
-  save_docker_compose
+function save_container_images() {
+  echo >&2 "## Saving container images to offline/images.txt and downloading them as .tar files"
+
+  local compose_yml=$1 version=$2 platform=$3 compose_dir
+  compose_dir=$(dirname "$compose_yml")
+
+  pushd "$compose_dir"
+  if [[ -f .env.template ]]; then
+    log::do cp .env.template .env
+  elif [[ -f compose-env ]]; then
+    log::do cp compose-env .env
+  else
+    log::error "No .env.template or compose-env file found."
+    exit 1
+  fi
+  (
+    PATH=../../aws/scripts:$SCRIPT_DIR:$PATH
+
+    set -o xtrace
+    VERSION="$version" setup.v2.sh --populate-env .env
+    $DOCKER compose --profile database --profile app --profile tools config | grep 'image:' | awk '{print $2}' >"$SCRIPT_DIR"/offline/images.txt
+  )
+  popd
+
+  pushd offline
+  local image image_filename
+  while read -r image; do
+    log::do $DOCKER pull --platform "$platform" "$image"
+    image_filename=$(echo "$image" | tr '/:' '__')
+    log::do $DOCKER save "$image" -o "${image_filename}".tar
+  done <images.txt
+}
+
+function main() {
+  local compose_yml=${1:-} version=${2:-} platform=${3:-linux/amd64}
+  if [[ -z ${compose_yml} || -z ${version} ]]; then
+    cat <<END_OF_USAGE
+Usage: $0 <compose.yml> <version> [platform]
+  compose.yml: Path to the docker-compose YAML file
+  version: QueryPie version to save as .tar (e.g., 11.1.2)
+  platform: Target platform for the container images (e.g., linux/amd64 or linux/arm64)
+
+EXAMPLES:
+  $0 universal/compose.yml 11.1.2 linux/amd64
+  $0 universal/compose.yml 11.1.2 linux/arm64
+
+END_OF_USAGE
+    exit 1
+  fi
+
+  echo >&2 "### Offline Package Archiver ###"
+  echo >&2 "# QueryPie version specified: $version"
+
+  log::do cd "$SCRIPT_DIR"
+  log::do archive_package "$compose_yml"
+  log::do save_docker_compose
+  log::do detect_container_engine
+  log::do save_container_images "$compose_yml" "$version" "$platform"
 }
 
 main "$@"

--- a/compose/offline-package.sh
+++ b/compose/offline-package.sh
@@ -38,8 +38,8 @@ function archive_package() {
   echo >&2 "## Creating offline/package.tar.gz from $compose_yml"
   compose_dir=$(dirname "$compose_yml")
   pushd "$compose_dir"
-  [[ -f ../offline/package.tar.gz ]] && rm -f ../offline/package.tar.gz
-  log::do tar zcvf ../offline/package.tar.gz .
+  [[ -f $SCRIPT_DIR/offline/package.tar.gz ]] && rm -f "$SCRIPT_DIR"/offline/package.tar.gz
+  log::do tar zcvf "$SCRIPT_DIR"/offline/package.tar.gz .
   popd
 }
 

--- a/compose/offline-package.sh
+++ b/compose/offline-package.sh
@@ -81,6 +81,8 @@ function save_container_images() {
     log::do cp .env.template .env
   elif [[ -f compose-env ]]; then
     log::do cp compose-env .env
+  elif [[ -f .env ]]; then
+    echo >&2 "# Using existing .env file."
   else
     log::error "No .env.template or compose-env file found."
     exit 1

--- a/compose/offline/.gitignore
+++ b/compose/offline/.gitignore
@@ -1,2 +1,4 @@
 package.tar.gz
 docker-compose-*
+images.txt
+*.tar


### PR DESCRIPTION
## 변경사항
- `offline-package.sh` 의 기능을 개선하여, Container Image 저장 기능을 추가합니다.
    - `compose.yml` 파일의 경로를 입력받습니다, `docker compose config` 명령을 활용하여, container image 이름을 알아냅니다. 이 image 의 내역을 `offline/images.txt` 에 저장합니다.
    - image 를 적당한 파일이름으로 바꾸어, `docker save`로 내보내기 수행합니다.
- 사용법
```
% ./offline-package.sh
Usage: ./offline-package.sh <compose.yml> <version> [platform]
  compose.yml: Path to the docker-compose YAML file
  version: QueryPie version to save as .tar (e.g., 11.1.2)
  platform: Target platform for the container images (e.g., linux/amd64 or linux/arm64)

EXAMPLES:
  ./offline-package.sh universal/compose.yml 11.1.2 linux/amd64
  ./offline-package.sh universal/compose.yml 11.1.2 linux/arm64
```

## 테스팅 결과
- `./offline-package.sh universal/compose.yml 11.1.2`: 성공
```
% ls -al offline
total 10254568
drwxr-xr-x  11 jk  staff         352 Aug 27 14:34 .
drwxr-xr-x   7 jk  staff         224 Aug 27 14:34 ..
-rw-r--r--   1 jk  staff          49 Aug 27 14:34 .gitignore
-rw-r--r--   1 jk  staff    73794306 Aug 27 14:30 docker-compose-linux-aarch64
-rw-r--r--   1 jk  staff    75601803 Aug 27 14:30 docker-compose-linux-x86_64
-rw-------   1 jk  staff   789076992 Aug 27 14:31 docker.io_querypie_mysql_8.0.42.tar
-rw-------   1 jk  staff   342200320 Aug 27 14:31 docker.io_querypie_querypie-tools_11.1.2.tar
-rw-------   1 jk  staff  3785147392 Aug 27 14:30 docker.io_querypie_querypie_11.1.2.tar
-rw-------   1 jk  staff   120216576 Aug 27 14:31 docker.io_querypie_redis_7.4.5.tar
-rw-r--r--   1 jk  staff         139 Aug 27 14:30 images.txt
-rw-r--r--   1 jk  staff        8884 Aug 27 14:30 package.tar.gz
```