### PR TITLE
Fix: bash script 의 log::do 를 개선합니다.

### DIFF
--- a/aws/ami/ami-build.sh
+++ b/aws/ami/ami-build.sh
@@ -7,14 +7,12 @@ BOLD_RED="\e[1;91m"
 RESET="\e[0m"
 
 function log::do() {
-  # print ascii color code for bold cyan and reset
+  local line_no
+  line_no=$(caller | awk '{print $1}')
+  # shellcheck disable=SC2064
+  trap "log::error 'Failed to run at line $line_no: $*'" ERR
   printf "%b+ %s%b\n" "$BOLD_CYAN" "$*" "$RESET" 1>&2
-  if "$@"; then
-    return 0
-  else
-    log::error "Failed to run: $*"
-    return 1
-  fi
+  "$@"
 }
 
 function log::error() {

--- a/aws/ami/ami-ls.sh
+++ b/aws/ami/ami-ls.sh
@@ -6,14 +6,12 @@ BOLD_CYAN="\e[1;36m"
 RESET="\e[0m"
 
 function log::do() {
-  # print ascii color code for bold cyan and reset
+  local line_no
+  line_no=$(caller | awk '{print $1}')
+  # shellcheck disable=SC2064
+  trap "log::error 'Failed to run at line $line_no: $*'" ERR
   printf "%b+ %s%b\n" "$BOLD_CYAN" "$*" "$RESET" 1>&2
-  if "$@"; then
-    return 0
-  else
-    log::error "Failed to run: $*"
-    return 1
-  fi
+  "$@"
 }
 
 function list_ami_images() {

--- a/aws/ami/ami-verify.sh
+++ b/aws/ami/ami-verify.sh
@@ -7,14 +7,12 @@ BOLD_RED="\e[1;91m"
 RESET="\e[0m"
 
 function log::do() {
-  # print ascii color code for bold cyan and reset
+  local line_no
+  line_no=$(caller | awk '{print $1}')
+  # shellcheck disable=SC2064
+  trap "log::error 'Failed to run at line $line_no: $*'" ERR
   printf "%b+ %s%b\n" "$BOLD_CYAN" "$*" "$RESET" 1>&2
-  if "$@"; then
-    return 0
-  else
-    log::error "Failed to run: $*"
-    return 1
-  fi
+  "$@"
 }
 
 function log::error() {

--- a/aws/ec2
+++ b/aws/ec2
@@ -19,13 +19,12 @@ readonly RESET="\e[0m"
 
 # Logging functions
 function log::do() {
+  local line_no
+  line_no=$(caller | awk '{print $1}')
+  # shellcheck disable=SC2064
+  trap "log::error 'Failed to run at line $line_no: $*'" ERR
   printf "%b+ %s%b\n" "$BOLD_CYAN" "$*" "$RESET" 1>&2
-  if "$@"; then
-    return 0
-  else
-    log::error "Failed to run: $*"
-    return 1
-  fi
+  "$@"
 }
 
 function log::warning() {

--- a/aws/scripts/setup.v2.sh
+++ b/aws/scripts/setup.v2.sh
@@ -63,14 +63,12 @@ BOLD_RED="\e[1;91m"
 RESET="\e[0m"
 
 function log::do() {
-  # print ascii color code for bold cyan and reset
+  local line_no
+  line_no=$(caller | awk '{print $1}')
+  # shellcheck disable=SC2064
+  trap "log::error 'Failed to run at line $line_no: $*'" ERR
   printf "%b+ %s%b\n" "$BOLD_CYAN" "$*" "$RESET" 1>&2
-  if "$@"; then
-    return 0
-  else
-    log::error "Failed to run: $*"
-    return 1
-  fi
+  "$@"
 }
 
 function log::warning() {

--- a/aws/scripts/setup.v2.sh
+++ b/aws/scripts/setup.v2.sh
@@ -63,10 +63,8 @@ BOLD_RED="\e[1;91m"
 RESET="\e[0m"
 
 function log::do() {
-  local line_no
-  line_no=$(caller | awk '{print $1}')
   # shellcheck disable=SC2064
-  trap "log::error 'Failed to run at line $line_no: $*'" ERR
+  trap "log::error 'Failed to run: $*'" ERR
   printf "%b+ %s%b\n" "$BOLD_CYAN" "$*" "$RESET" 1>&2
   "$@"
 }

--- a/aws/verify-install/verify-install.sh
+++ b/aws/verify-install/verify-install.sh
@@ -7,14 +7,12 @@ BOLD_RED="\e[1;91m"
 RESET="\e[0m"
 
 function log::do() {
-  # print ascii color code for bold cyan and reset
+  local line_no
+  line_no=$(caller | awk '{print $1}')
+  # shellcheck disable=SC2064
+  trap "log::error 'Failed to run at line $line_no: $*'" ERR
   printf "%b+ %s%b\n" "$BOLD_CYAN" "$*" "$RESET" 1>&2
-  if "$@"; then
-    return 0
-  else
-    log::error "Failed to run: $*"
-    return 1
-  fi
+  "$@"
 }
 
 function log::error() {

--- a/aws/verify-upgrade-uninstall/verify-upgrade-uninstall.sh
+++ b/aws/verify-upgrade-uninstall/verify-upgrade-uninstall.sh
@@ -7,14 +7,12 @@ BOLD_RED="\e[1;91m"
 RESET="\e[0m"
 
 function log::do() {
-  # print ascii color code for bold cyan and reset
+  local line_no
+  line_no=$(caller | awk '{print $1}')
+  # shellcheck disable=SC2064
+  trap "log::error 'Failed to run at line $line_no: $*'" ERR
   printf "%b+ %s%b\n" "$BOLD_CYAN" "$*" "$RESET" 1>&2
-  if "$@"; then
-    return 0
-  else
-    log::error "Failed to run: $*"
-    return 1
-  fi
+  "$@"
 }
 
 function log::error() {

--- a/compose/offline-package.sh
+++ b/compose/offline-package.sh
@@ -16,13 +16,12 @@ readonly RESET="\e[0m"
 
 # Logging functions
 function log::do() {
+  local line_no
+  line_no=$(caller | awk '{print $1}')
+  # shellcheck disable=SC2064
+  trap "log::error 'Failed to run at line $line_no: $*'" ERR
   printf "%b+ %s%b\n" "$BOLD_CYAN" "$*" "$RESET" 1>&2
-  if "$@"; then
-    return 0
-  else
-    log::error "Failed to run: $*"
-    return 1
-  fi
+  "$@"
 }
 
 function log::warning() {


### PR DESCRIPTION
## 변경사항
- 여러 bash script 에 사용되는 `log::do` 함수를 개선합니다.
  - Ctrl-C 입력하여 Interrupt 하는 경우, bash script 가 실행을 중단하도록, 개선합니다.
  - 오류가 발생한 bash script line number 를 에러메시지에 노출합니다.

## 추가 설명
- `if "$@"; then return 0; else return 1; fi` 방식의 코드는 오류 발생시 bash 의 행동을 바꾸게 됩니다.
- Ctrl-C 입력에 따른 Interrupt 의 경우, `log::do command`의 실행이 중단되지 않고, 계속 실행되는 현상이 발생할 수 있습니다.
  - `while read -r variable;` loop 내에서 ` log::do command` 로 실행 중인 명령을 Ctrl-C 로 중단하는 경우, script 실행이 멈추지 않고 계속 진행됩니다.
  - `push-to-private-registry.sh` 스크립트 구현 과정에서 이러한 문제가 발견되었습니다.