### PR TITLE
setup.v2.sh - OFFLINE_DIR 에서 .tar 이미지를 설치합니다.

### DIFF
--- a/compose/offline-package.sh
+++ b/compose/offline-package.sh
@@ -92,15 +92,17 @@ function save_container_images() {
     set -o xtrace
     VERSION="$version" setup.v2.sh --populate-env .env
     $DOCKER compose --profile database --profile app --profile tools config | grep 'image:' | awk '{print $2}' >"$SCRIPT_DIR"/offline/images.txt
+    $DOCKER compose --file novac-compose.yml --profile novac config | grep 'image:' | awk '{print $2}' >>"$SCRIPT_DIR"/offline/images.txt
   )
   popd
 
   pushd offline
-  local image image_filename
+  local image tarball hardware
+  hardware=$(basename "$platform")
   while read -r image; do
     log::do $DOCKER pull --platform "$platform" "$image"
-    image_filename=$(echo "$image" | tr '/:' '__')
-    log::do $DOCKER save "$image" -o "${image_filename}".tar
+    tarball=$(echo "$image" | tr '/:' '__')-${hardware}.tar
+    log::do $DOCKER save "$image" -o "${tarball}"
   done <images.txt
 }
 


### PR DESCRIPTION
## 변경사항
- OFFLINE_DIR 의 기본값은 `./offline/`입니다.
- setup.v2.sh 에서 `install::load_image_from_tarball_in_offline`을 구현합니다.
  - OFFLINE_DIR 에 `images.txt`가 존재하는 경우, 이 파일을 읽어, container image 를 로딩합니다.
- setup.v2.sh 에서, 신규 설치 `cmd::install`,  업그레이드 `cmd::upgrade`, 두 가지 명령 수행시, Compose Package 압축 해제 직후, `install::load_image_from_tarball_in_offline` 를 수행합니다.
  - `install::load_image_from_tarball_in_offline` 에서 container image 가 로딩된 경우, docker compose pull 을 생략하고 실행하지 않습니다.
- offline-package.sh 개선사항
  - `novac` 이미지를 save 합니다.
  - .tar 이름에 hardware 이름을 추가합니다. 이에 따라, `-amd64.tar` 또는 `-arm64.tar` 파일이 만들어 집니다.

## 테스팅 결과
- local macbook 에서 setup.v2.sh 가 OFFLINE_DIR 의 이미지를 로딩하는데 성공합니다.
```
jk@Jk-Kim-VVVY6C7KYV offline % ls -al
total 20225488
drwxr-xr-x  17 jk  staff         544 Aug 28 14:20 .
drwxr-xr-x   8 jk  staff         256 Aug 28 14:12 ..
-rw-r--r--   1 jk  staff          49 Aug 27 17:00 .gitignore
-rw-r--r--   1 jk  staff    73794306 Aug 28 11:23 docker-compose-linux-aarch64
-rw-r--r--   1 jk  staff    75601803 Aug 28 11:23 docker-compose-linux-x86_64
-rw-------   1 jk  staff   789076992 Aug 28 11:17 docker.io_querypie_mysql_8.0.42-amd64.tar
-rw-------   1 jk  staff   784970752 Aug 28 11:23 docker.io_querypie_mysql_8.0.42-arm64.tar
-rw-------   1 jk  staff    20501504 Aug 28 11:17 docker.io_querypie_novac_11.1.2-amd64.tar
-rw-------   1 jk  staff    21084160 Aug 28 11:24 docker.io_querypie_novac_11.1.2-arm64.tar
-rw-------   1 jk  staff   342200320 Aug 28 11:17 docker.io_querypie_querypie-tools_11.1.2-amd64.tar
-rw-------   1 jk  staff   345713664 Aug 28 11:24 docker.io_querypie_querypie-tools_11.1.2-arm64.tar
-rw-------   1 jk  staff  3785147392 Aug 28 11:17 docker.io_querypie_querypie_11.1.2-amd64.tar
-rw-------   1 jk  staff  3786485248 Aug 28 11:23 docker.io_querypie_querypie_11.1.2-arm64.tar
-rw-------   1 jk  staff   120216576 Aug 28 11:17 docker.io_querypie_redis_7.4.5-amd64.tar
-rw-------   1 jk  staff   142832128 Aug 28 11:23 docker.io_querypie_redis_7.4.5-arm64.tar
-rw-r--r--   1 jk  staff         171 Aug 28 11:23 images.txt
-rw-r--r--   1 jk  staff        8888 Aug 28 11:22 package.tar.gz
jk@Jk-Kim-VVVY6C7KYV offline % cat images.txt 
docker.io/querypie/querypie:11.1.2
docker.io/querypie/mysql:8.0.42
docker.io/querypie/redis:7.4.5
docker.io/querypie/querypie-tools:11.1.2
docker.io/querypie/novac:11.1.2
jk@Jk-Kim-VVVY6C7KYV offline %
```
