### PR TITLE
setup.v2.sh: OFFLINE_DIR 설치 버그 수정

### DIFF
--- a/aws/verify-install/rhel-9.pkr.hcl
+++ b/aws/verify-install/rhel-9.pkr.hcl
@@ -150,7 +150,7 @@ build {
     ]
   }
 
-  # Install scripts such as setup.v2.sh
+  # Copy files in scripts, such as setup.v2.sh
   provisioner "file" {
     source      = "../scripts/"
     destination = "/tmp/"
@@ -164,12 +164,6 @@ build {
         var.container_engine == "podman" ? "/tmp/install-podman-on-rhel.sh" : "true",
         var.container_engine == "none" ? "/tmp/setup.v2.sh --container-engine-only" : "true",
     ]
-  }
-
-  # Install scripts such as setup.v2.sh
-  provisioner "file" {
-    source      = "../scripts/"
-    destination = "/tmp/"
   }
   provisioner "shell" {
     inline_shebang = "/bin/bash -ex"

--- a/compose/local-image-prune.sh
+++ b/compose/local-image-prune.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -o nounset -o errexit -o xtrace
+
+if docker --version 2>/dev/null | grep -q "^Docker version"; then
+  DOCKER=docker
+elif podman --version 2>/dev/null | grep -q "^podman version"; then
+  DOCKER=podman
+else
+  echo >&2 "# Unknown version of Docker"
+  docker --version
+  exit 1
+fi
+
+$DOCKER image prune --all --force || true


### PR DESCRIPTION
## 변경사항
- `install::load_image_from_tarball_in_offline`의 버그를 수정합니다.
  - hardware 값이 `x86_64` 인 경우, `amd64` 로 값을 대체합니다.
  - hardware 값이 `aarch64` 인 경우, `arm64` 로 값을 대체합니다.

## 참고사항 
- container platform 은 `linux/amd64`, `linux/arm64` 로 구분됩니다.
- docker-compose 실행파일은 `x86_64`,  `aarch64` 로 구분됩니다.
- `$(uname -m | tr '[:upper:]' '[:lower:]')`의 값은 리눅스의 경우 `x86_64`, `aarch64`, macOS 의 경우 `arm64`로 구분됩니다.

## 테스팅 결과
아래 4개 명령이 모두 기대한대로 작동합니다.
- `./verify-install.sh 11.1.1 rhel-8-offline x86_64 podman`
- `./verify-install.sh 11.1.1 rhel-8-offline x86_64 docker`
- `./verify-install.sh 11.1.1 rhel-8-offline arm64 podman`
- `./verify-install.sh 11.1.1 rhel-8-offline arm64 docker`
