### PR TITLE
setup.v2.sh: setup.sh 호환기능을 구현합니다.

### DIFF
--- a/aws/verify-install/amazon-linux-2023.pkr.hcl
+++ b/aws/verify-install/amazon-linux-2023.pkr.hcl
@@ -161,7 +161,7 @@ build {
     inline = [
         var.container_engine == "docker" ? "/tmp/install-docker-on-amazon-linux-2023.sh" : "true",
         var.container_engine == "podman" ? "/tmp/podman-unavailable.sh" : "true",
-        var.container_engine == "none" ? "/tmp/setup.v2.sh --container-engine-only" : "true",
+        var.container_engine == "none" ? "/tmp/setup.v2.sh --install-container-engine" : "true",
     ]
   }
 

--- a/aws/verify-install/centos-9.pkr.hcl
+++ b/aws/verify-install/centos-9.pkr.hcl
@@ -164,7 +164,7 @@ build {
         # CentOS 9 can use the same installation scripts as RHEL 8
         var.container_engine == "docker" ? "/tmp/install-docker-on-rhel.sh" : "true",
         var.container_engine == "podman" ? "/tmp/install-podman-on-rhel.sh" : "true",
-        var.container_engine == "none" ? "/tmp/setup.v2.sh --container-engine-only" : "true",
+        var.container_engine == "none" ? "/tmp/setup.v2.sh --install-container-engine" : "true",
     ]
   }
 

--- a/aws/verify-install/rhel-10.pkr.hcl
+++ b/aws/verify-install/rhel-10.pkr.hcl
@@ -162,7 +162,7 @@ build {
     inline = [
         var.container_engine == "docker" ? "/tmp/docker-unavailable.sh" : "true",
         var.container_engine == "podman" ? "/tmp/install-podman-on-rhel.sh" : "true",
-        var.container_engine == "none" ? "/tmp/setup.v2.sh --container-engine-only" : "true",
+        var.container_engine == "none" ? "/tmp/setup.v2.sh --install-container-engine" : "true",
     ]
   }
 

--- a/aws/verify-install/rhel-8-offline.pkr.hcl
+++ b/aws/verify-install/rhel-8-offline.pkr.hcl
@@ -162,7 +162,7 @@ build {
     inline = [
         var.container_engine == "docker" ? "/tmp/install-docker-on-rhel.sh" : "true",
         var.container_engine == "podman" ? "/tmp/install-podman-on-rhel.sh" : "true",
-        var.container_engine == "none" ? "/tmp/setup.v2.sh --container-engine-only" : "true",
+        var.container_engine == "none" ? "/tmp/setup.v2.sh --install-container-engine" : "true",
     ]
   }
   provisioner "shell" {

--- a/aws/verify-install/rhel-8.pkr.hcl
+++ b/aws/verify-install/rhel-8.pkr.hcl
@@ -161,7 +161,7 @@ build {
     inline = [
         var.container_engine == "docker" ? "/tmp/install-docker-on-rhel.sh" : "true",
         var.container_engine == "podman" ? "/tmp/install-podman-on-rhel.sh" : "true",
-        var.container_engine == "none" ? "/tmp/setup.v2.sh --container-engine-only" : "true",
+        var.container_engine == "none" ? "/tmp/setup.v2.sh --install-container-engine" : "true",
     ]
   }
   provisioner "shell" {

--- a/aws/verify-install/rhel-9.pkr.hcl
+++ b/aws/verify-install/rhel-9.pkr.hcl
@@ -162,7 +162,7 @@ build {
     inline = [
         var.container_engine == "docker" ? "/tmp/install-docker-on-rhel.sh" : "true",
         var.container_engine == "podman" ? "/tmp/install-podman-on-rhel.sh" : "true",
-        var.container_engine == "none" ? "/tmp/setup.v2.sh --container-engine-only" : "true",
+        var.container_engine == "none" ? "/tmp/setup.v2.sh --install-container-engine" : "true",
     ]
   }
   provisioner "shell" {

--- a/aws/verify-install/rocky-8.pkr.hcl
+++ b/aws/verify-install/rocky-8.pkr.hcl
@@ -167,7 +167,7 @@ build {
     inline = [
         var.container_engine == "docker" ? "/tmp/install-docker-on-rhel.sh" : "true",
         var.container_engine == "podman" ? "/tmp/install-podman-on-rhel.sh" : "true",
-        var.container_engine == "none" ? "/tmp/setup.v2.sh --container-engine-only" : "true",
+        var.container_engine == "none" ? "/tmp/setup.v2.sh --install-container-engine" : "true",
     ]
   }
 

--- a/aws/verify-install/ubuntu-22.04.pkr.hcl
+++ b/aws/verify-install/ubuntu-22.04.pkr.hcl
@@ -162,7 +162,7 @@ build {
         var.container_engine == "docker" ? "/tmp/install-docker-on-ubuntu.sh" : "true",
         # Podman on Ubuntu 22.04 is not officially supported, because the version is too old (Podman 3.4.4).
         var.container_engine == "podman" ? "/tmp/podman-unavailable.sh" : "true",
-        var.container_engine == "none" ? "/tmp/setup.v2.sh --container-engine-only" : "true",
+        var.container_engine == "none" ? "/tmp/setup.v2.sh --install-container-engine" : "true",
     ]
   }
 

--- a/aws/verify-install/ubuntu-24.04.pkr.hcl
+++ b/aws/verify-install/ubuntu-24.04.pkr.hcl
@@ -161,7 +161,7 @@ build {
     inline = [
         var.container_engine == "docker" ? "/tmp/install-docker-on-ubuntu.sh" : "true",
         var.container_engine == "podman" ? "/tmp/install-podman-on-ubuntu.sh" : "true",
-        var.container_engine == "none" ? "/tmp/setup.v2.sh --container-engine-only" : "true",
+        var.container_engine == "none" ? "/tmp/setup.v2.sh --install-container-engine" : "true",
     ]
   }
 


### PR DESCRIPTION
## 변경사항
- `setup.v2.sh --install-compose-package <version>` 옵션을 구현합니다.
  - 이 기능은 기존 `setup.sh`와 동등한 설치 기능으로, container engine 설치, compose package 설치까지만 수행합니다.
  - .env 자동 설정, container 실행, migration 실행 등을 수행하지 않습니다.
- .env 파일이 symbolic link 인 경우, 이를 삭제하고, .env.template 또는 compose-env 를 .env 로 복사합니다.
- 설치 도중 실패한 경우, 문제를 해결하고, 다시 재설치하는 경우, mysql db password 등이 변경되지 않도록, .env 를 그대로 유지합니다.
  - .env 파일이 일반 파일로 이미 존재하는 경우, 이를 덮어쓰지 않고, 그대로 활용합니다. 같은 버전으로 두번 설치하는 것을 허용합니다.

## 테스팅 결과
```
jk@Jk-Kim-VVVY6C7KYV ~ % ./setup.v2.sh --install-compose-package 
#### setup.v2.sh - QueryPie Installer 25.08.8, /opt/homebrew/bin/bash 5.2.21(1)-release on Darwin arm64 ####
ERROR: Version is required. Please provide a version.
setup.v2.sh 25.08.8, the QueryPie installation script.
Usage: setup.v2.sh [options]
    or setup.v2.sh [options] --install <version>
    or setup.v2.sh [options] --install-container-engine
    or setup.v2.sh [options] --install-compose-package <version>
    or setup.v2.sh [options] --upgrade <version>
    or setup.v2.sh [options] --uninstall
    or setup.v2.sh [options] --help

FOR AWS AMI BUILD MAINTAINER:
    or setup.v2.sh [options] --install-partially-for-ami <version>
    or setup.v2.sh [options] --resume
    or setup.v2.sh [options] --verify-installation
    or setup.v2.sh [options] --verify-not-installed
    or setup.v2.sh [options] --populate-env <env-file>
    or setup.v2.sh [options] --reset-credential <env-file>

ENVIRONMENT VARIABLES:

  DOCKER_REGISTRY                Default: 'docker.io/querypie/'
    The Docker registry to pull images from.
    You may specify a private registry such as 'myregistry.example.com/querypie/'.
    Note that the trailing slash is required, if you set this variable.
    Actual image names will be like 'myregistry.example.com/querypie/querypie:11.1.1'.

OPTIONS:
  --yes               Assume "yes" to all prompts and run non-interactively.
  -V, --version       Show the version of this script.
  -x, --xtrace        Print commands and their arguments as they are executed.
  -h, --help          Show this help message.

jk@Jk-Kim-VVVY6C7KYV ~ % ./setup.v2.sh --install-compose-package 11.1.2
#### setup.v2.sh - QueryPie Installer 25.08.8, /opt/homebrew/bin/bash 5.2.21(1)-release on Darwin arm64 ####
### Install Compose package only
## This command is compatible with setup.sh (v1), which installs docker-compose package only.
# QP_VERSION: 11.1.2
# PACKAGE_VERSION: universal
#
## Configure sudo privileges
#
# 'sudo' will be used for privileged commands.
#
## Install Docker engine
#
# Docker is already installed at /usr/local/bin/docker
#
## Verify Container Engine installation
#
# Docker is already running and functional.
+ docker --version
Docker version 28.3.2, build 578ccf6
#
## Install Docker Compose tool
#
# Compose Tool, docker-compose is already installed at /Users/jk/.docker/cli-plugins/docker-compose
# Compose Tool is enabled as a plugin for docker
+ docker compose version
Docker Compose version v2.39.1-desktop.1
#
## Install configuration files: docker-compose.yml, .env, and others
#
# Target directory is ./querypie/11.1.2/
# Detected an ./offline/package.tar.gz file.
# This file will be used instead of downloading a new one.
# Such behavior is intended for closed or air-gapped environments.
+ cp ./offline/package.tar.gz package.tar.gz
+ umask 0022
+ tar zxvf package.tar.gz -C ./querypie/11.1.2
x ./
x ./skip_command_config.json
x ./systemd/
x ./logrotate
x ./README.md
x ./README.ja.md
x ./.env.template
x ./certs/
x ./.gitignore
x ./mysql_init/
x ./.env
x ./skip_command_config.json.example
x ./novac-compose.yml
x ./README.ko.md
x ./nginx.d/
x ./compose.yml
x ./nginx.d/.gitkeep
x ./nginx.d/ssl.conf
x ./mysql_init/init.sql
x ./certs/.gitkeep
x ./systemd/podman-querypie-app.service
x ./systemd/podman-querypie-database.service
+ rm package.tar.gz
+ sed -i.orig -e s#- \./mysql:/var/lib/mysql#- ../mysql:/var/lib/mysql# -e s#harbor.chequer.io/querypie/#docker.io/querypie/# -e s#docker.io/querypie/#docker.io/querypie/# -e s#source: /var/log/querypie#source: ../log# ./querypie/11.1.2/compose.yml
# ./querypie/11.1.2/.env already exists.
# No need to create a new .env file.
+ sed -i.orig -e s#^VERSION=.*#VERSION=11.1.2# -e s#CABINET_DATA_DIR=/data#CABINET_DATA_DIR=../data# ./querypie/11.1.2/.env
+ mkdir -p ./querypie/mysql
+ mkdir -p ./querypie/log
+ sudo cp ./querypie/11.1.2/logrotate /etc/logrotate.d/docker-querypie
#
## Verify SELinux settings
#
# SELinux is not found. Skipping SELinux settings verification.
#
## No ./offline/images.txt file found. Skipping loading Docker images from tarball files.
#
### Installation completed successfully
```