### PR TITLE
Tencent: cvm - VM Stop, Start, Terminate 하는 도구

### DIFF
--- a/aws/ec2
+++ b/aws/ec2
@@ -9,7 +9,7 @@
 # Ensure script exits on error
 set -o nounset -o errexit -o errtrace -o pipefail
 
-readonly SCRIPT_VERSION="25.08.3" # YY.MM.PATCH
+readonly SCRIPT_VERSION="25.09.1" # YY.MM.PATCH
 
 # Color definitions
 readonly BOLD_CYAN="\e[1;36m"

--- a/tencent-cloud/cvm
+++ b/tencent-cloud/cvm
@@ -1,0 +1,372 @@
+#!/usr/bin/env bash
+# Tencent Cloud CVM Instance Management Script
+# This script provides a simple interface to manage Tencent Cloud CVM instances.
+# Usage:
+#   ./cvm start   - Start all instances owned by the current user
+#   ./cvm stop    - Stop all instances owned by the current user
+#   ./cvm status  - List instances owned by the current user
+
+# Ensure script exits on error
+set -o nounset -o errexit -o errtrace -o pipefail
+
+readonly SCRIPT_VERSION="25.08.3" # YY.MM.PATCH
+
+# Color definitions
+readonly BOLD_CYAN="\e[1;36m"
+readonly BOLD_YELLOW="\e[1;33m"
+readonly BOLD_RED="\e[1;91m"
+readonly RESET="\e[0m"
+
+# Logging functions
+function log::do() {
+  local line_no
+  line_no=$(caller | awk '{print $1}')
+  # shellcheck disable=SC2064
+  trap "log::error 'Failed to run at line $line_no: $*'" ERR
+  printf "%b+ %s%b\n" "$BOLD_CYAN" "$*" "$RESET" 1>&2
+  "$@"
+}
+
+function log::warning() {
+  printf "%bWARNING: %s%b\n" "$BOLD_YELLOW" "$*" "$RESET" 1>&2
+}
+
+function log::error() {
+  printf "%bERROR: %s%b\n" "$BOLD_RED" "$*" "$RESET" 1>&2
+}
+
+# Tencent Cloud CLI validation functions
+function tccli::check_cli() {
+  if ! command -v tccli >/dev/null 2>&1; then
+    log::error "Tencent Cloud CLI (tccli) is not installed."
+    echo >&2 "## Installation guide: https://cloud.tencent.com/document/product/440/34011"
+    exit 1
+  fi
+}
+
+function tccli::check_credentials() {
+  if ! tccli configure list >/dev/null 2>&1; then
+    log::error "Tencent Cloud credentials are not configured."
+    echo >&2 "## Configure credentials using: tccli configure"
+    exit 1
+  fi
+}
+
+function cvm::get_username_variations() {
+  local username=$1 username_lower username_upper username_capitalized
+
+  # Create username variations
+  username_lower=$(echo "${username}" | tr '[:upper:]' '[:lower:]')
+  username_upper=$(echo "${username}" | tr '[:lower:]' '[:upper:]')
+  username_capitalized="${username^}"
+
+  # Return comma-separated list
+  echo "${username_lower},${username_upper},${username_capitalized}"
+}
+
+# Write instance list rows (no header) into the specified tmp file.
+# Columns (tab-separated): Name, InstanceId, State, Type, PublicIP, PrivateIP, Created
+function cvm::show_instance_list() {
+  local out_file=${1:-}
+  if [[ -z "${out_file}" ]]; then
+    log::error "cvm::show_instance_list requires an output file path argument"
+    return 1
+  fi
+  local username username_list
+  username=${USERNAME:-$(whoami)}
+  echo >&2 "## Listing CVM instances owned by ${username}..."
+
+  username_list=$(cvm::get_username_variations "${username}")
+  
+  # Create temporary file for JSON data
+  local json_tmp_file
+  json_tmp_file=$(mktemp -t cvm_json_XXXXXX)
+  # shellcheck disable=SC2064
+  trap "rm -f ${json_tmp_file}" RETURN
+
+  # Get all instances from Tencent Cloud API
+  log::do tccli cvm DescribeInstances \
+    --output json >"${json_tmp_file}" || true
+
+  # Check if we got any data
+  if [[ ! -s "${json_tmp_file}" ]] || grep -qx "None" "${json_tmp_file}"; then
+    log::warning "No instances found with Owner tag matching ${username} (variations: ${username_list})"
+    return
+  fi
+
+  # Parse JSON, filter by Owner tag, and write filtered results to out_file
+  python3 -c "
+import json
+import sys
+try:
+    with open('${json_tmp_file}', 'r') as f:
+        data = json.load(f)
+    
+    username_variations = '${username_list}'.split(',')
+    
+    # Collect filtered instances
+    filtered_instances = []
+    for instance in data.get('InstanceSet', []):
+        # Check if instance has Owner tag matching any variation
+        owner_match = False
+        for tag in instance.get('Tags', []):
+            if tag.get('Key') == 'Owner':
+                tag_value = tag.get('Value', '')
+                if tag_value in username_variations:
+                    owner_match = True
+                    break
+        
+        if owner_match:
+            name = instance.get('InstanceName', 'NoName')
+            public_ip = instance.get('PublicIpAddresses', ['-'])[0] if instance.get('PublicIpAddresses') else '-'
+            private_ip = instance.get('PrivateIpAddresses', ['-'])[0] if instance.get('PrivateIpAddresses') else '-'
+            filtered_instances.append([
+                name,
+                instance.get('InstanceId', '-'),
+                instance.get('InstanceState', '-'),
+                instance.get('InstanceType', '-'),
+                public_ip,
+                private_ip,
+                instance.get('CreatedTime', '-')
+            ])
+    
+    # Sort by CreatedTime (LaunchTime equivalent)
+    filtered_instances.sort(key=lambda x: x[6])
+    
+    # Write to output file in AWS EC2 --output text format
+    with open('${out_file}', 'w') as f:
+        for instance in filtered_instances:
+            f.write('\t'.join(instance) + '\n')
+            
+except Exception as e:
+    print(f'Error parsing JSON: {e}', file=sys.stderr)
+    sys.exit(1)
+" 2>/dev/null || true
+
+  # Check if we got any filtered results
+  if [[ ! -s "${out_file}" ]]; then
+    log::warning "No instances found with Owner tag matching ${username} (variations: ${username_list})"
+    return
+  fi
+
+  # Display results with header
+  {
+    printf "Name\tInstanceId\tState\tType\tPublicIP\tPrivateIP\tCreated\n"
+    cat "${out_file}" || true
+  } | sed -e 's/\bNone\b/-/g' | column -t -s $'\t'
+}
+
+function cvm::start() {
+  # Show the list first
+  local tmp_file
+  tmp_file=$(mktemp -t cvm_describe_XXXXXX)
+  # shellcheck disable=SC2064
+  trap "rm -f ${tmp_file}" RETURN
+  # Populate describe-instances output into a temp file via helper, then post-process
+  cvm::show_instance_list "${tmp_file}"
+
+  # Collect eligible instance IDs (only stopped) and start them in a single call
+  local name instance_id state type public_ip private_ip created
+  local -a eligible_ids=()
+  while IFS=$'\t' read -r name instance_id state type public_ip private_ip created; do
+    # Validate instance_id format (Tencent Cloud CVM instance IDs start with 'ins-')
+    if [[ -z "${instance_id:-}" ]] || [[ ! "${instance_id}" =~ ^ins-[a-zA-Z0-9]+$ ]]; then
+      continue
+    fi
+
+    # Only start instances that are currently stopped; silently skip others
+    case "${state}" in
+    "STOPPED")
+      eligible_ids+=("${instance_id}")
+      ;;
+    *)
+      :
+      ;;
+    esac
+  done < "${tmp_file}"
+
+  if [[ ${#eligible_ids[@]} -eq 0 ]]; then
+    log::warning "No eligible instances to start."
+    return
+  fi
+
+  echo >&2 "## Starting instances: ${eligible_ids[*]}..."
+  # Convert array to JSON format for tccli
+  local json_ids
+  json_ids=$(python3 -c "import json; print(json.dumps(\"${eligible_ids[*]}\".split()))")
+  if log::do tccli cvm StartInstances --InstanceIds "${json_ids}" >/dev/null; then
+    echo >&2 "## Start request submitted for: ${eligible_ids[*]}"
+  else
+    log::error "Failed to start one or more instances."
+    exit 1
+  fi
+}
+
+function cvm::stop() {
+  # Show the list first
+  local tmp_file
+  tmp_file=$(mktemp -t cvm_describe_XXXXXX)
+  # shellcheck disable=SC2064
+  trap "rm -f ${tmp_file}" RETURN
+  # Populate describe-instances output into a temp file via helper, then post-process
+  cvm::show_instance_list "${tmp_file}"
+
+  # Collect eligible instance IDs and stop them in a single call
+  local name instance_id state type public_ip private_ip created
+  local -a eligible_ids=()
+  while IFS=$'\t' read -r name instance_id state type public_ip private_ip created; do
+    # Validate instance_id format (Tencent Cloud CVM instance IDs start with 'ins-')
+    if [[ -z "${instance_id:-}" ]] || [[ ! "${instance_id}" =~ ^ins-[a-zA-Z0-9]+$ ]]; then
+      continue
+    fi
+
+    case "${state}" in
+    "TERMINATED"|"SHUTTING_DOWN"|"STOPPING"|"STOPPED")
+      continue
+      ;;
+    esac
+
+    eligible_ids+=("${instance_id}")
+  done < "${tmp_file}"
+
+  if [[ ${#eligible_ids[@]} -eq 0 ]]; then
+    log::warning "No eligible instances to stop."
+    return
+  fi
+
+  echo >&2 "## Stopping instances: ${eligible_ids[*]}..."
+  # Convert array to JSON format for tccli
+  local json_ids
+  json_ids=$(python3 -c "import json; print(json.dumps(\"${eligible_ids[*]}\".split()))")
+  if log::do tccli cvm StopInstances --InstanceIds "${json_ids}" >/dev/null; then
+    echo >&2 "## Stop request submitted for: ${eligible_ids[*]}"
+  else
+    log::error "Failed to stop one or more instances."
+    exit 1
+  fi
+}
+
+function cvm::status() {
+  local tmp_file
+  tmp_file=$(mktemp -t cvm_describe_XXXXXX)
+  # Ensure a temp file is removed on return from this function
+  # shellcheck disable=SC2064
+  trap "rm -f ${tmp_file}" RETURN
+
+  # Populate the tmp_file with an instance list via helper
+  cvm::show_instance_list "${tmp_file}"
+}
+
+function cvm::terminate() {
+  # Show the list first
+  local tmp_file
+  tmp_file=$(mktemp -t cvm_describe_XXXXXX)
+  # shellcheck disable=SC2064
+  trap "rm -f ${tmp_file}" RETURN
+  # Populate describe-instances output into a temp file via helper, then post-process
+  cvm::show_instance_list "${tmp_file}"
+
+  echo "For each instance below, type 'yes' to confirm termination. Any other input will skip."
+
+  # Read rows directly from tmp_file and process per-instance without materializing all IDs
+  local name instance_id state type public_ip private_ip created
+  # Open tmp_file on FD 9 so stdin remains available for user prompts inside the loop
+  exec 9< "${tmp_file}"
+  while IFS=$'\t' read -r name instance_id state type public_ip private_ip created <&9; do
+    # Validate instance_id format (Tencent Cloud CVM instance IDs start with 'ins-')
+    if [[ -z "${instance_id:-}" ]] || [[ ! "${instance_id}" =~ ^ins-[a-zA-Z0-9]+$ ]]; then
+      continue
+    fi
+
+    case "${state}" in
+    "TERMINATED")
+      log::warning "Instance ${instance_id} (${name:-NoName}) is already terminated. Skipping."
+      continue
+      ;;
+    "SHUTTING_DOWN")
+      log::warning "Instance ${instance_id} (${name:-NoName}) is already shutting down. Skipping."
+      continue
+      ;;
+    esac
+
+    printf "Confirm terminate %s (%s) [%s] [%s] " \
+      "${instance_id}" "${name:-NoName}" "${public_ip:-}" "${private_ip:-}" 1>&2
+
+    if ask_yes "[type 'yes' to proceed]: "; then
+      echo >&2 "## Terminating instance ${instance_id}..."
+      # Convert single instance ID to JSON format for tccli
+      local json_id
+      json_id=$(python3 -c "import json; print(json.dumps([\"${instance_id}\"]))")
+      if log::do tccli cvm TerminateInstances --InstanceIds "${json_id}" >/dev/null; then
+        echo >&2 "## Instance ${instance_id} termination request submitted."
+      else
+        log::error "Failed to terminate instance ${instance_id}."
+        exit 1
+      fi
+    else
+      echo >&2 "## Skipped ${instance_id}."
+    fi
+  done
+  # Close FD 9
+  exec 9<&-
+}
+
+function ask_yes() {
+  printf "%s" "$1" >&2
+  local answer
+  read -r answer # zsh compatibility: zsh does not support read -p prompt.
+  case "${answer}" in
+  y | Y | yes | YES | Yes) return ;;
+  *) return 1 ;;
+  esac
+}
+
+function cvm::help() {
+  local username
+  username=${USERNAME:-$(whoami)}
+  echo "Tencent Cloud CVM Instance Management Script v${SCRIPT_VERSION}"
+  echo ""
+  echo "Usage:"
+  echo "  $0 start     - Start all instances owned by ${username}"
+  echo "  $0 stop      - Stop all instances owned by ${username}"
+  echo "  $0 terminate - Terminate instances owned by ${username} (per-instance confirmation)"
+  echo "  $0 status    - List instances owned by ${username}"
+  echo "  $0 help      - Show this help message"
+  echo ""
+  echo "Note: This script automatically finds and manages all CVM instances"
+  echo "      tagged with Owner=${username} (case-insensitive matching)"
+  echo ""
+}
+
+function main() {
+  # Check Tencent Cloud CLI and credentials
+  tccli::check_cli
+  tccli::check_credentials
+
+  # Process command
+  case "${1:-help}" in
+  "start")
+    cvm::start
+    ;;
+  "stop")
+    cvm::stop
+    ;;
+  "terminate")
+    cvm::terminate
+    ;;
+  "status")
+    cvm::status
+    ;;
+  "help" | "-h" | "--help")
+    cvm::help
+    ;;
+  *)
+    log::error "Unknown command: $1"
+    echo ""
+    cvm::help
+    exit 1
+    ;;
+  esac
+}
+
+main "$@"


### PR DESCRIPTION
## 변경사항
- /aws/ec2 스크립트를 활용하여, 동일한 기능을 제공하는 스크립트를 /tencent-cloud/cvm 으로 작성합니다.
- start, stop, terminate 기능을 검증하였습니다.

## 사용방법
```
% ./cvm
Tencent Cloud CVM Instance Management Script v25.08.3

Usage:
  ./cvm start     - Start all instances owned by jk
  ./cvm stop      - Stop all instances owned by jk
  ./cvm terminate - Terminate instances owned by jk (per-instance confirmation)
  ./cvm status    - List instances owned by jk
  ./cvm help      - Show this help message

Note: This script automatically finds and manages all CVM instances
      tagged with Owner=jk (case-insensitive matching)
```