### PR TITLE
Tencent: cvm stop 명령에 STOP_CHARGING 적용

### DIFF
--- a/tencent-cloud/cvm
+++ b/tencent-cloud/cvm
@@ -9,7 +9,7 @@
 # Ensure script exits on error
 set -o nounset -o errexit -o errtrace -o pipefail
 
-readonly SCRIPT_VERSION="25.08.3" # YY.MM.PATCH
+readonly SCRIPT_VERSION="25.09.1" # YY.MM.PATCH
 
 # Color definitions
 readonly BOLD_CYAN="\e[1;36m"
@@ -234,12 +234,12 @@ function cvm::stop() {
     return
   fi
 
-  echo >&2 "## Stopping instances: ${eligible_ids[*]}..."
+  echo >&2 "## Stopping instances with STOP_CHARGING: ${eligible_ids[*]}..."
   # Convert array to JSON format for tccli
   local json_ids
   json_ids=$(python3 -c "import json; print(json.dumps(\"${eligible_ids[*]}\".split()))")
-  if log::do tccli cvm StopInstances --InstanceIds "${json_ids}" >/dev/null; then
-    echo >&2 "## Stop request submitted for: ${eligible_ids[*]}"
+  if log::do tccli cvm StopInstances --InstanceIds "${json_ids}" --StopType "SOFT" --StoppedMode "STOP_CHARGING" >/dev/null; then
+    echo >&2 "## Stop request submitted for: ${eligible_ids[*]} (billing will be stopped)"
   else
     log::error "Failed to stop one or more instances."
     exit 1
@@ -328,13 +328,14 @@ function cvm::help() {
   echo ""
   echo "Usage:"
   echo "  $0 start     - Start all instances owned by ${username}"
-  echo "  $0 stop      - Stop all instances owned by ${username}"
+  echo "  $0 stop      - Stop all instances owned by ${username} (with billing stopped)"
   echo "  $0 terminate - Terminate instances owned by ${username} (per-instance confirmation)"
   echo "  $0 status    - List instances owned by ${username}"
   echo "  $0 help      - Show this help message"
   echo ""
   echo "Note: This script automatically finds and manages all CVM instances"
   echo "      tagged with Owner=${username} (case-insensitive matching)"
+  echo "      Stop command uses STOP_CHARGING to minimize billing costs."
   echo ""
 }
 


### PR DESCRIPTION
## 변경사항
- Tencent Cloud 는 VM 을 Stop 할 때, Public IP Address 등을 반환하는 조건으로 비용 청구를 더 낮추는 STOP_CHARGING 모드를 제공합니다.
- `cvm stop`에 STOP_CHARGING 옵션을 기본 적용합니다.

## 테스팅 결과
```
(.venv) jk@Jk-Kim-VVVY6C7KYV tencent-cloud % ./cvm stop
## Listing CVM instances owned by jk...
+ tccli cvm DescribeInstances --output json
Name         InstanceId    State    Type         PublicIP        PrivateIP    Created
jk-ubuntu24  ins-r3qubu7n  RUNNING  SA5.LARGE16  43.155.131.158  10.99.32.16  2025-08-24T03:35:48Z
## Stopping instances with STOP_CHARGING: ins-r3qubu7n...
+ tccli cvm StopInstances --InstanceIds ["ins-r3qubu7n"] --StopType SOFT --StoppedMode STOP_CHARGING
## Stop request submitted for: ins-r3qubu7n (billing will be stopped)
(.venv) jk@Jk-Kim-VVVY6C7KYV tencent-cloud % 
```