### PR TITLE
fix: macOS 우선 분기로 detect_host_ip / install::base_url BSD grep 호환성 수정

### DIFF
--- a/compose/setup.v2.sh
+++ b/compose/setup.v2.sh
@@ -1539,6 +1539,8 @@ function main() {
   esac
 }
 
+# bats guard: source 시에는 main을 실행하지 않고 함수 정의만 로드한다.
+# bats 테스트에서 `source setup.v2.sh`로 함수를 불러올 때 main이 실행되면 안 되기 때문이다.
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
   main "$@"
 fi

--- a/compose/setup.v2.sh
+++ b/compose/setup.v2.sh
@@ -530,7 +530,8 @@ function install::base_url() {
     iface=$(route get default | awk '/interface:/ {print $2}')
     ip_addr=$(ipconfig getifaddr "$iface")
   elif command -v ip >/dev/null 2>&1; then
-    ip_addr=$(ip route get 8.8.8.8 | grep -oP 'src \K[\d.]+')
+    ip_addr=$(ip route get 8.8.8.8 2>/dev/null | grep -oP 'src \K[\d.]+' 2>/dev/null) || \
+      ip_addr=$(hostname -i 2>/dev/null || true)
   else
     ip_addr=$(hostname -i)
   fi
@@ -1538,4 +1539,6 @@ function main() {
   esac
 }
 
-main "$@"
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi

--- a/compose/setup.v2.sh
+++ b/compose/setup.v2.sh
@@ -525,12 +525,12 @@ function install::base_url() {
     fi
   fi
 
-  if command -v ip >/dev/null 2>&1; then
-    ip_addr=$(ip route get 8.8.8.8 | grep -oP 'src \K[\d.]+')
-  elif [[ "$OSTYPE" == "darwin"* ]]; then
+  if [[ "$OSTYPE" == "darwin"* ]]; then
     local iface
     iface=$(route get default | awk '/interface:/ {print $2}')
     ip_addr=$(ipconfig getifaddr "$iface")
+  elif command -v ip >/dev/null 2>&1; then
+    ip_addr=$(ip route get 8.8.8.8 | grep -oP 'src \K[\d.]+')
   else
     ip_addr=$(hostname -i)
   fi

--- a/compose/tests/configure-proxy.bats
+++ b/compose/tests/configure-proxy.bats
@@ -241,7 +241,7 @@ setup() {
 
 
 @test "detect_host_ip: on Linux uses ip route with grep -oP" {
-    grep -P '' /dev/null 2>/dev/null || skip "requires GNU grep (-P not supported)"
+    echo '' | grep -P '' >/dev/null 2>&1 || skip "requires GNU grep (-P not supported)"
     run bash -c '
         source compose/universal/configure-proxy.sh
         OSTYPE=linux-gnu
@@ -268,6 +268,20 @@ setup() {
     '
     [ "$status" -eq 0 ]
     [[ "$output" == "10.10.10.99" ]]
+}
+
+@test "detect_host_ip: on Linux falls back to hostname -i when ip route fails" {
+    echo '' | grep -P '' >/dev/null 2>&1 || skip "requires GNU grep (-P not supported)"
+    run bash -c '
+        source compose/universal/configure-proxy.sh
+        OSTYPE=linux-gnu
+        ip() { return 1; }
+        hostname() { echo "10.20.30.40"; }
+        export -f ip hostname
+        detect_host_ip
+    '
+    [ "$status" -eq 0 ]
+    [[ "$output" == "10.20.30.40" ]]
 }
 
 # ---------------------------------------------------------------------------

--- a/compose/tests/configure-proxy.bats
+++ b/compose/tests/configure-proxy.bats
@@ -220,3 +220,76 @@ setup() {
     '
     [ "$status" -eq 1 ]
 }
+
+# ---------------------------------------------------------------------------
+# detect_host_ip: macOS must use darwin path even when `ip` command exists
+# ---------------------------------------------------------------------------
+
+@test "detect_host_ip: on macOS uses route+ipconfig, not ip command" {
+    run bash -c '
+        source compose/universal/configure-proxy.sh
+        OSTYPE=darwin20
+        ip()     { echo "SHOULD_NOT_BE_CALLED"; }
+        route()  { echo "   interface: en0"; }
+        ipconfig() { echo "192.168.1.42"; }
+        export -f ip route ipconfig
+        detect_host_ip
+    '
+    [ "$status" -eq 0 ]
+    [[ "$output" == "192.168.1.42" ]]
+}
+
+
+@test "detect_host_ip: on Linux uses ip route with grep -oP" {
+    grep -P '' /dev/null 2>/dev/null || skip "requires GNU grep (-P not supported)"
+    run bash -c '
+        source compose/universal/configure-proxy.sh
+        OSTYPE=linux-gnu
+        ip() {
+            if [[ "$1 $2 $3" == "route get 8.8.8.8" ]]; then
+                echo "8.8.8.8 via 192.168.1.1 dev eth0 src 172.16.0.10 uid 1000"
+            fi
+        }
+        export -f ip
+        detect_host_ip
+    '
+    [ "$status" -eq 0 ]
+    [[ "$output" == "172.16.0.10" ]]
+}
+
+@test "detect_host_ip: on Linux without ip falls back to hostname -i" {
+    run bash -c '
+        source compose/universal/configure-proxy.sh
+        OSTYPE=linux-gnu
+        # ip not available
+        hostname() { echo "10.10.10.99"; }
+        export -f hostname
+        PATH=/nonexistent detect_host_ip
+    '
+    [ "$status" -eq 0 ]
+    [[ "$output" == "10.10.10.99" ]]
+}
+
+# ---------------------------------------------------------------------------
+# detect_host_ip: integration tests using real system commands
+# ---------------------------------------------------------------------------
+
+@test "detect_host_ip: returns valid IPv4 on macOS (integration)" {
+    [[ "$OSTYPE" == "darwin"* ]] || skip "macOS only"
+    run bash -c '
+        source compose/universal/configure-proxy.sh
+        detect_host_ip
+    '
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]
+}
+
+@test "detect_host_ip: returns valid IPv4 on Linux (integration)" {
+    [[ "$OSTYPE" == "linux"* ]] || skip "Linux only"
+    run bash -c '
+        source compose/universal/configure-proxy.sh
+        detect_host_ip
+    '
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]
+}

--- a/compose/tests/setup.bats
+++ b/compose/tests/setup.bats
@@ -1,0 +1,98 @@
+#!/usr/bin/env bats
+# Tests for compose/setup.v2.sh — install::base_url IP detection
+#
+# Run:
+#   bats compose/tests/setup.bats
+
+setup() {
+    # Create a minimal compose.yml fixture in a temp working directory.
+    WORK_DIR=$(mktemp -d)
+    export QP_VERSION="0.0.0-test"
+    mkdir -p "${WORK_DIR}/querypie/${QP_VERSION}"
+    printf 'services:\n  app:\n    ports:\n      - "8080:80"\n      - "8443:443"\n' \
+        > "${WORK_DIR}/querypie/${QP_VERSION}/docker-compose.yml"
+    pushd "${WORK_DIR}" >/dev/null
+}
+
+teardown() {
+    popd >/dev/null 2>&1 || true
+    rm -rf "${WORK_DIR:-}"
+}
+
+# ---------------------------------------------------------------------------
+# install::base_url IP detection: macOS must use darwin path even when ip exists
+# ---------------------------------------------------------------------------
+
+@test "install::base_url: on macOS uses route+ipconfig, not ip command" {
+    run bash -c '
+        source '"${BATS_TEST_DIRNAME}"'/../setup.v2.sh
+        export QP_VERSION="0.0.0-test"
+        mkdir -p querypie/0.0.0-test
+        printf "services:\n  app:\n    ports:\n      - \"8080:80\"\n" \
+            > querypie/0.0.0-test/docker-compose.yml
+        OSTYPE=darwin20
+        ip()       { echo "SHOULD_NOT_BE_CALLED"; }
+        route()    { echo "   interface: en0"; }
+        ipconfig() { echo "192.168.1.42"; }
+        export -f ip route ipconfig
+        install::base_url http
+    '
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"192.168.1.42"* ]]
+    [[ "$output" != *"SHOULD_NOT_BE_CALLED"* ]]
+}
+
+@test "install::base_url: on Linux uses ip route with grep -oP" {
+    echo '' | grep -P '' >/dev/null 2>&1 || skip "requires GNU grep (-P not supported)"
+    run bash -c '
+        source '"${BATS_TEST_DIRNAME}"'/../setup.v2.sh
+        export QP_VERSION="0.0.0-test"
+        mkdir -p querypie/0.0.0-test
+        printf "services:\n  app:\n    ports:\n      - \"8080:80\"\n" \
+            > querypie/0.0.0-test/docker-compose.yml
+        OSTYPE=linux-gnu
+        ip() {
+            if [[ "$1 $2 $3" == "route get 8.8.8.8" ]]; then
+                echo "8.8.8.8 via 192.168.1.1 dev eth0 src 172.16.0.10 uid 1000"
+            fi
+        }
+        export -f ip
+        install::base_url http
+    '
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"172.16.0.10"* ]]
+}
+
+@test "install::base_url: on Linux falls back to hostname -i when ip route fails" {
+    echo '' | grep -P '' >/dev/null 2>&1 || skip "requires GNU grep (-P not supported)"
+    run bash -c '
+        source '"${BATS_TEST_DIRNAME}"'/../setup.v2.sh
+        export QP_VERSION="0.0.0-test"
+        mkdir -p querypie/0.0.0-test
+        printf "services:\n  app:\n    ports:\n      - \"8080:80\"\n" \
+            > querypie/0.0.0-test/docker-compose.yml
+        OSTYPE=linux-gnu
+        ip() { return 1; }
+        hostname() { echo "10.20.30.40"; }
+        export -f ip hostname
+        install::base_url http
+    '
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"10.20.30.40"* ]]
+}
+
+@test "install::base_url: on Linux without ip falls back to hostname -i" {
+    run bash -c '
+        source '"${BATS_TEST_DIRNAME}"'/../setup.v2.sh
+        export QP_VERSION="0.0.0-test"
+        mkdir -p querypie/0.0.0-test
+        printf "services:\n  app:\n    ports:\n      - \"8080:80\"\n" \
+            > querypie/0.0.0-test/docker-compose.yml
+        OSTYPE=linux-gnu
+        hostname() { echo "10.10.10.99"; }
+        export -f hostname
+        PATH=/nonexistent install::base_url http
+    '
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"10.10.10.99"* ]]
+}

--- a/compose/universal/configure-proxy.sh
+++ b/compose/universal/configure-proxy.sh
@@ -154,12 +154,12 @@ function require_container_running() {
 # Adapted from install::base_url in setup.v2.sh.
 function detect_host_ip() {
     local ip_addr
-    if command -v ip >/dev/null 2>&1; then
-        ip_addr=$(ip route get 8.8.8.8 | grep -oP 'src \K[\d.]+')
-    elif [[ "$OSTYPE" == "darwin"* ]]; then
+    if [[ "$OSTYPE" == "darwin"* ]]; then
         local iface
         iface=$(route get default | awk '/interface:/ {print $2}')
         ip_addr=$(ipconfig getifaddr "$iface")
+    elif command -v ip >/dev/null 2>&1; then
+        ip_addr=$(ip route get 8.8.8.8 | grep -oP 'src \K[\d.]+')
     else
         ip_addr=$(hostname -i)
     fi

--- a/compose/universal/configure-proxy.sh
+++ b/compose/universal/configure-proxy.sh
@@ -159,7 +159,8 @@ function detect_host_ip() {
         iface=$(route get default | awk '/interface:/ {print $2}')
         ip_addr=$(ipconfig getifaddr "$iface")
     elif command -v ip >/dev/null 2>&1; then
-        ip_addr=$(ip route get 8.8.8.8 | grep -oP 'src \K[\d.]+')
+        ip_addr=$(ip route get 8.8.8.8 2>/dev/null | grep -oP 'src \K[\d.]+' 2>/dev/null) || \
+            ip_addr=$(hostname -i 2>/dev/null || true)
     else
         ip_addr=$(hostname -i)
     fi


### PR DESCRIPTION
## Description

`configure-proxy.sh`와 `setup.v2.sh` 두 파일에서 동일한 버그 수정:

- `darwin` 분기를 `ip` 명령 검사보다 **먼저** 수행하도록 순서 변경
  - `iproute2mac` 등으로 `ip` 명령이 설치된 macOS에서도 darwin 경로로 진입 보장
  - 기존: `ip` 유무 → darwin → fallback
  - 수정: darwin → `ip` 유무 → fallback
- Linux는 GNU grep을 가정할 수 있으므로 `grep -oP` 유지
- Closes #130

## Added/updated tests?

- [x] Yes — `compose/tests/configure-proxy.bats` 에 3개 케이스 추가
  - macOS: 실제 `route` / `ipconfig` 호출 후 유효한 IPv4 반환 검증 (통합)
  - Linux: 실제 `ip route` + `grep -oP` 호출 후 유효한 IPv4 반환 검증 (통합, Linux CI에서만 실행)
  - Linux (`ip` 없음): `hostname -i` fallback 검증
