### PR TITLE
fix(setup.v2.sh): Docker Compose 설치 후 v2 provider 교체 여부 재검증

### DIFF
--- a/compose/setup.v2.sh
+++ b/compose/setup.v2.sh
@@ -8,7 +8,7 @@
 # $ bash setup.v2.sh --upgrade <version>
 
 # The version will be manually increased by the author.
-SCRIPT_VERSION="26.03.1" # YY.MM.PATCH
+SCRIPT_VERSION="26.03.2" # YY.MM.PATCH
 echo -n "#### setup.v2.sh - QueryPie Installer ${SCRIPT_VERSION}, " >&2
 echo -n "${BASH:-}${ZSH_NAME:-} ${BASH_VERSION:-}${ZSH_VERSION:-}" >&2
 echo >&2 " on $(uname -s) $(uname -m) ####"
@@ -368,13 +368,15 @@ function install::docker_compose() {
     log::do rm docker-compose
   fi
 
-  if $DOCKER compose version &>/dev/null; then
+  local post_install_ver
+  post_install_ver=$($DOCKER compose version 2>/dev/null || true)
+  if [[ "$post_install_ver" == *"Docker Compose version v2"* ]] || [[ "$post_install_ver" == *"Docker Compose version v5"* ]]; then
     echo >&2 "# Now Docker Compose is installed at $(command::whereis docker-compose || echo '(Unknown)')"
     echo >&2 "# Docker Compose is enabled as a plugin for $DOCKER"
     log::do $DOCKER compose version
     return
   else
-    echo >&2 "# Failed to install Docker Compose properly: $($DOCKER compose version 2>&1 || true)"
+    echo >&2 "# Failed to install Docker Compose properly: ${post_install_ver}"
     log::error "Please report this problem to the technical support team of QueryPie."
     log::do uname -a
     log::do ${DOCKER} --version


### PR DESCRIPTION
## Description

- `install::docker_compose()` 에서 Docker Compose v2 설치 후, provider가 실제로 v2로 교체됐는지 검증하는 로직을 추가합니다.
- 기존 코드는 `$DOCKER compose version &>/dev/null` — exit code만 확인하여, Podman 환경에서 legacy docker-compose v1이 provider로 고정된 경우 통과해버리는 버그가 있었습니다.
- 설치 후 버전 문자열을 다시 읽어 `"Docker Compose version v2"` 또는 `"Docker Compose version v5"` 포함 여부를 검증하도록 변경합니다.

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: 스크립트 통합 테스트 환경 없음

## Additional notes

- Closes #131