### PR TITLE
fix(aws): verify-upgrade-uninstall ubuntu-22.04 packer source 이름 오타 수정

### DIFF
--- a/aws/verify-upgrade-uninstall/ubuntu-22.04.pkr.hcl
+++ b/aws/verify-upgrade-uninstall/ubuntu-22.04.pkr.hcl
@@ -98,7 +98,7 @@ data "amazon-ami" "ubuntu-22-04" {
 # source : Keyword to begin a source block
 # amazon-ebs : Type of builder, or plugin name
 # ubuntu-22-04 : Name of the builder
-source "amazon-ebs" "ubuntu22-04" {
+source "amazon-ebs" "ubuntu-22-04" {
   skip_create_ami = true
   source_ami      = data.amazon-ami.ubuntu-22-04.id
   ami_name        = local.ami_name


### PR DESCRIPTION
## Description

- `build.sources`의 참조 이름 `ubuntu-22-04`에 맞춰 `source` 블록 선언도 `ubuntu22-04` → `ubuntu-22-04`로 통일합니다.

**수정 전:**
```
source "amazon-ebs" "ubuntu22-04" { ... }
sources = ["source.amazon-ebs.ubuntu-22-04"]  # mismatch
```

**수정 후:**
```
source "amazon-ebs" "ubuntu-22-04" { ... }
sources = ["source.amazon-ebs.ubuntu-22-04"]  # ok
```

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: `packer validate`로 검증 완료

## Additional notes

- PR #132 리뷰에서 발견된 이슈 대응
