### PR TITLE
setup.v2.sh 기본 QueryPie 설치 버전을 11.6.2로 변경

### DIFF
--- a/compose/setup.v2.sh
+++ b/compose/setup.v2.sh
@@ -17,7 +17,7 @@ echo >&2 " on $(uname -s) $(uname -m) ####"
 [[ -n "${ZSH_VERSION:-}" ]] && emulate bash
 set -o nounset -o errexit -o pipefail
 
-RECOMMENDED_VERSION="11.6.0" # QueryPie version to install by default.
+RECOMMENDED_VERSION="11.6.2" # QueryPie version to install by default.
 ASSUME_YES=false
 DOCKER=docker          # The default Container Engine
 COMPOSE=docker-compose # The default Compose tool


### PR DESCRIPTION
요약
- `compose/setup.v2.sh`의 기본 설치 버전(`RECOMMENDED_VERSION`)을 `11.6.2`로 변경했습니다.

변경 사항
- 기본 QueryPie 설치 버전: `11.6.0` -> `11.6.2`

테스트
- 별도 로컬 실행은 하지 않았습니다.
- 상수값 변경 1건만 포함합니다.
