### PR TITLE
setup.v2.sh 기본 QueryPie 설치 버전을 11.6.3로 변경

### DIFF
--- a/compose/setup.v2.sh
+++ b/compose/setup.v2.sh
@@ -8,7 +8,7 @@
 # $ bash setup.v2.sh --upgrade <version>
 
 # The version will be manually increased by the author.
-SCRIPT_VERSION="26.03.2" # YY.MM.PATCH
+SCRIPT_VERSION="26.05.1" # YY.MM.PATCH
 echo -n "#### setup.v2.sh - QueryPie Installer ${SCRIPT_VERSION}, " >&2
 echo -n "${BASH:-}${ZSH_NAME:-} ${BASH_VERSION:-}${ZSH_VERSION:-}" >&2
 echo >&2 " on $(uname -s) $(uname -m) ####"
@@ -17,7 +17,7 @@ echo >&2 " on $(uname -s) $(uname -m) ####"
 [[ -n "${ZSH_VERSION:-}" ]] && emulate bash
 set -o nounset -o errexit -o pipefail
 
-RECOMMENDED_VERSION="11.6.2" # QueryPie version to install by default.
+RECOMMENDED_VERSION="11.6.3" # QueryPie version to install by default.
 ASSUME_YES=false
 DOCKER=docker          # The default Container Engine
 COMPOSE=docker-compose # The default Compose tool


### PR DESCRIPTION
## 요약
- `compose/setup.v2.sh`의 기본 QueryPie 설치 버전을 `11.6.3`으로 업데이트했습니다.
- 스크립트 자체 버전을 `26.05.1`로 업데이트했습니다.

## 검증
- `git diff --check`
- `bash -n compose/setup.v2.sh`
