### PR TITLE
feat: add QueryPie audit and history report tools

### DIFF
--- a/querypie-report/AGENTS.md
+++ b/querypie-report/AGENTS.md
@@ -1,0 +1,43 @@
+# 작업 지침
+
+이 저장소는 QueryPie 감사·이력 데이터를 조회하거나 CSV로 추출하기 위한 SQL과 Python 2.7 호환 도구를 포함합니다. SQL은 모두 읽기 전용 조회 도구입니다.
+
+## 데이터 추출 전 확인
+
+1. 사용자의 요청에 맞는 하위 디렉터리를 선택합니다.
+2. **반드시 해당 디렉터리의 `README.md`를 먼저 읽습니다.** README에는 조회 목적, 필요한 DB 권한·환경변수, 기간 설정, 실행 방법, 출력 컬럼과 민감 데이터 유의 사항이 있습니다.
+3. README의 설명과 SQL/스크립트의 실제 조건이 일치하는지 확인한 뒤 필요한 데이터만 추출합니다.
+
+## 디렉터리별 라우팅
+
+| 요청 유형 | 사용할 디렉터리 |
+| --- | --- |
+| Workflow SQL, 승인선, Query Audit, Ledger 매칭, DML Snapshot | `workflow_sql_audit_export/` |
+| Ledger 정책 테이블별 DML 건수 | `ledger_workflow_dml_count/` |
+| 사용자 생성·삭제·잠김·해제·만료 또는 로그인 성공·실패 이력 | `user_history/` |
+| 성공 Query Audit 상세 | `query_audit/` |
+| 성공·Ledger DML Workflow 또는 승인자별 Workflow 이력 | `workflow_sql_history/` |
+| Connection 접근 사용자·역할·권한·Owner | `access_control/` |
+| 모든 DB 유형의 Ledger 정책 대상 테이블 | `ledger_policy/` |
+| Activity Log의 변경 전·후 값 | `activity_log/` |
+
+## 시간대 원칙
+
+- QueryPie 내부의 시각 컬럼은 UTC로 저장된다는 전제로 SQL을 작성합니다.
+- 기간을 입력받는 SQL은 변수명을 `*_kst`로 두고, 비교할 때 KST 입력값에서 9시간을 빼 UTC 저장값과 비교합니다.
+- 시각을 출력하는 SQL은 UTC 저장값에 9시간을 더하고, 가능하면 컬럼명에 `_kst`를 붙이거나 README에 KST임을 명시합니다.
+- 현재 시각과 UTC 저장 만료 시각을 비교할 때는 세션 시간대에 의존하는 `NOW()` 대신 `UTC_TIMESTAMP()`를 사용합니다.
+- 날짜 단위 기준일은 UTC 날짜가 아니라 KST로 변환한 날짜를 기준으로 판정합니다.
+
+## 실행 원칙
+
+- 조회 조건(특히 기간과 대상)을 먼저 확인하고, 요청 범위를 넘는 데이터를 추출하지 않습니다.
+- DB 접속 정보와 비밀번호는 환경변수 또는 안전한 인증 방법으로만 제공합니다. 코드·README·명령 기록에 비밀번호를 추가하지 않습니다.
+- SQL과 스크립트는 읽기 전용 조회 용도로 사용합니다. `INSERT`, `UPDATE`, `DELETE`, `DROP` 등 변경 작업은 사용자의 명시적 요청 없이는 수행하지 않습니다.
+- Workflow Snapshot 데이터는 민감할 수 있으므로, `INCLUDE_DML_SNAPSHOTS=true`는 사용자가 명시적으로 필요하다고 한 경우에만 사용합니다.
+- SQL을 실행하기 전에는 대상 기간, Connection·사용자 등 범위와 KST 입력값을 확인합니다.
+
+## 문서 유지
+
+- SQL 또는 스크립트의 입력, 실행 방법, 출력 컬럼 또는 시간대 처리를 변경하면 같은 디렉터리의 `README.md`도 함께 갱신합니다.
+- 새 조회 도구를 추가하면 상위 `README.md`의 디렉터리 안내와 이 파일의 라우팅 표도 갱신합니다.

--- a/querypie-report/README.md
+++ b/querypie-report/README.md
@@ -1,0 +1,32 @@
+# QueryPie 감사·이력 조회 도구
+
+이 디렉터리는 QueryPie의 Workflow SQL 실행 이력, Query Audit, Ledger 정책, 사용자·접근 권한·Activity Log 이력을 조회·추출하기 위한 독립 실행 도구와 SQL 모음입니다. 모든 SQL은 읽기 전용이며, 내부 시각은 UTC 저장값을 기준으로 KST 입력·출력으로 처리합니다.
+
+## 디렉터리 안내
+
+| 디렉터리 | 목적 | 시작 문서 |
+| --- | --- | --- |
+| [workflow_sql_audit_export](workflow_sql_audit_export/) | 승인·실행 완료된 SQL Workflow를 CSV로 추출하고 Query Audit, Ledger 정책, 선택적 DML Snapshot 데이터를 결합 | [README.md](workflow_sql_audit_export/README.md) |
+| [ledger_workflow_dml_count](ledger_workflow_dml_count/) | 활성 Ledger 정책 테이블별 DML Query Audit 건수를 기간 단위로 집계 | [README.md](ledger_workflow_dml_count/README.md) |
+| [user_history](user_history/) | 사용자 생성·삭제와 계정 잠김·해제·만료, 로그인 성공·실패 이력 조회 | [README.md](user_history/README.md) |
+| [query_audit](query_audit/) | 성공한 Query Audit의 실행 SQL·Connection·권한·처리량 상세 조회 | [README.md](query_audit/README.md) |
+| [workflow_sql_history](workflow_sql_history/) | 성공·Ledger DML Workflow 및 승인자 기준 SQL Workflow 이력 조회 | [README.md](workflow_sql_history/README.md) |
+| [access_control](access_control/) | Connection 접근 사용자, 역할 부여, 권한 상세, Owner 조회 | [README.md](access_control/README.md) |
+| [ledger_policy](ledger_policy/) | 모든 DB 유형의 활성 Ledger 정책 테이블 목록 조회 | [README.md](ledger_policy/README.md) |
+| [activity_log](activity_log/) | Activity Log의 변경 전·후 값 조회 | [README.md](activity_log/README.md) |
+
+## 빠른 선택
+
+- 특정 기간의 SQL Workflow, 승인자, 실행 쿼리, Ledger 여부를 CSV로 받아야 하면 `workflow_sql_audit_export`를 사용합니다.
+- Ledger 정책 테이블에 대해 실제 DML이 얼마나 수행됐는지 확인하려면 `ledger_workflow_dml_count`를 사용합니다.
+- 사용자 계정 생성·삭제·잠김 관련 이력이나 로그인 성공·실패 이력을 확인하려면 `user_history`를 사용합니다.
+- Query Audit 원본 상세가 필요하면 `query_audit`, Workflow DML/승인 이력은 `workflow_sql_history`를 사용합니다.
+- Connection 권한은 `access_control`, 모든 DB 유형의 Ledger 정책 대상은 `ledger_policy`, 변경 전·후 Activity Log는 `activity_log`를 사용합니다.
+
+## 공통 유의 사항
+
+- 각 도구의 하위 README를 먼저 읽고, 기간·DB 연결 정보·출력 컬럼을 확인한 뒤 실행하세요.
+- SQL은 App DB(`querypie`)와 Log DB(`querypie_log`)를 함께 조회할 수 있습니다. 실행 계정에는 필요한 읽기 권한이 있어야 합니다.
+- SQL의 기간 변수는 특별한 설명이 없는 한 KST로 입력합니다. QueryPie 내부 시각은 UTC로 저장되므로, 각 하위 README의 KST 변환 규칙을 유지하세요.
+- DB 접속 비밀번호는 파일이나 명령행에 기록하지 말고 환경변수 또는 안전한 인증 방식을 사용하세요.
+- Workflow Snapshot 출력에는 변경 전·후의 민감한 값이 포함될 수 있으므로, 필요한 경우에만 옵션을 켜고 결과 파일의 접근 권한을 관리하세요.

--- a/querypie-report/access_control/README.md
+++ b/querypie-report/access_control/README.md
@@ -1,0 +1,119 @@
+# 접근 권한 조회
+
+Connection별 역할 부여, 현재 접근 가능 사용자, 권한 부여 이력, Connection Owner를 조회하는 SQL 모음입니다. 모든 SQL은 App DB(`querypie`) 읽기 권한이 필요합니다.
+
+## 파일 선택
+
+| 파일 | 사용 목적 | 주요 입력 |
+| --- | --- | --- |
+| `role_grants_as_of_date.sql` | 특정 기준일에 특정 Connection에 유효한 역할 부여 현황 | 기준일, Connection 이름 |
+| `connection_accessible_users.sql` | 모든 Connection에 현재 접근 가능한 사용자와 사용자 수 | 없음(현재 시각 기준) |
+| `connection_privilege_grants.sql` | 기간 중 새로 부여된 Connection 권한의 상세 | 시작 시각, 종료 시각(KST) |
+| `connection_owners.sql` | 모든 Connection의 Connection Owner 목록(사용자 이름을 한 셀에 묶음) | 없음 |
+| `connection_owner_assignments.sql` | Connection Owner를 Connection·사용자 단위로 상세 조회 | 없음 |
+
+## `role_grants_as_of_date.sql`
+
+특정 날짜에 한 Connection에 유효한 역할 부여를 조회합니다. SQL 상단에서 아래 변수를 수정합니다.
+
+```sql
+SET @as_of_date = '2026-03-31';
+SET @connection_name = CONVERT('connection-name' USING utf8mb4) COLLATE utf8mb4_general_ci;
+```
+
+삭제되지 않은 사용자와 역할 부여만 대상으로 하며, 부여일부터 만료일 사이에 기준일이 포함되는 권한을 출력합니다. 만료일이 없으면 무기한 권한으로 처리합니다.
+
+기준일과 모든 시각 출력은 KST 기준입니다. SQL은 UTC 저장 시각을 KST 날짜로 변환해 기준일을 비교합니다.
+
+`cluster_groups.name`이 `utf8mb4_general_ci`이고 접속 세션이 `utf8mb4_0900_ai_ci`인 환경에서는 Connection 이름 비교 시 collation 오류가 발생할 수 있습니다. SQL은 `@connection_name`을 `utf8mb4_general_ci`로 명시해 이 오류를 방지합니다. Connection 이름만 변경하고 `CONVERT` 및 `COLLATE` 부분은 유지하세요.
+
+| 컬럼 | 설명 |
+| --- | --- |
+| `User Type` | 권한이 부여된 사용자 객체 유형 |
+| `User Name` | 사용자 이름 |
+| `Connection Name` | 대상 Connection 이름 |
+| `DB Host` | 대상 DB 호스트 |
+| `Replication Type` | DB 복제 유형. `MASTER`/`SLAVE`/`SINGLE`을 사람이 읽기 쉬운 값으로 변환 |
+| `Role Name` | 부여된 Connection 역할 이름 |
+| `Status` | SQL의 `enabled`/`expired` 상태 표현값 |
+| `Granted At` | 권한 부여 시각(KST) |
+| `Expiration At` | 권한 만료 시각(KST). 값이 없으면 무기한 |
+| `Renewed At` | 권한 갱신 시각(KST) |
+| `Last Access At` | 마지막 접근 시각(KST) |
+
+## `connection_accessible_users.sql`
+
+모든 활성 Connection별로 현재 접근 가능한 사용자 수와 사용자 목록을 조회합니다. 직접 사용자에게 부여된 권한뿐 아니라 사용자 그룹을 통해 부여된 권한도 포함하며, 중복 사용자는 한 번만 집계합니다.
+
+현재 활성 권한은 삭제되지 않았고, 활성화되어 있으며, 만료되지 않았고, 만료 시각이 없거나 현재 시각보다 미래인 권한으로 판단합니다. 만료 시각이 UTC로 저장되므로 세션 시간대와 무관하게 `UTC_TIMESTAMP()`로 비교합니다. 사용자 목록이 길 수 있어 실행 시 `group_concat_max_len`을 1,000,000으로 설정합니다.
+
+| 컬럼 | 설명 |
+| --- | --- |
+| `connection_uuid` | Connection UUID |
+| `connection_name` | Connection 이름 |
+| `assigned_user_count` | 현재 접근 가능한 고유 사용자 수 |
+| `assigned_users` | `login_id (사용자명)` 형식으로 연결한 현재 접근 가능 사용자 목록 |
+
+## `connection_privilege_grants.sql`
+
+지정 기간에 부여된 Connection 권한을 상세하게 조회합니다. SQL 상단에서 기간을 수정합니다.
+
+```sql
+SET @start_kst = '2025-01-01 00:00:00';
+SET @end_kst = '2025-12-31 00:00:00';
+```
+
+입력값은 KST 기준입니다. SQL은 UTC로 저장된 권한 부여 시각과 비교할 때 9시간을 빼며, 모든 권한 시각은 KST로 출력합니다. 시작일은 포함하고 종료일 다음 날 직전까지 포함합니다. 즉, 종료일 전체를 조회합니다.
+
+`스키마 범위 (NULL=전체)` 컬럼은 Schema 권한이 활성화된 환경에서만 사용합니다. Schema 권한을 사용하지 않는 환경에서는 SQL의 `crm.schemas AS \`스키마 범위 (NULL=전체)\`,` 선택 항목을 제거한 뒤 실행하세요.
+
+| 컬럼 | 설명 |
+| --- | --- |
+| `커넥션명` | Connection 이름 |
+| `DB 유형` | Connection DB 유형 |
+| `호스트` | DB 호스트 |
+| `포트` | DB 포트 |
+| `로그인 ID` | 권한이 부여된 사용자의 Login ID |
+| `사용자명` | 권한이 부여된 사용자 이름 |
+| `이메일` | 권한이 부여된 사용자 이메일 |
+| `부서` | 권한이 부여된 사용자 부서 |
+| `역할명` | 부여된 역할 이름 |
+| `권한 DB 유형` | 역할이 적용되는 DB 벤더 유형 |
+| `권한 목록 (DML/DCL/DDL)` | 역할에 설정된 권한 유형 목록 |
+| `Can Import` | Import 허용 여부 (`Y`/`N`) |
+| `Can Export` | Export 허용 여부 (`Y`/`N`) |
+| `Can Copy to Clipboard` | Clipboard 복사 허용 여부 (`Y`/`N`) |
+| `스키마 범위 (NULL=전체)` | 역할이 적용되는 Schema 범위. `NULL`이면 전체. Schema 권한을 사용하지 않는 환경에서는 SQL에서 이 컬럼을 제거 |
+| `권한 부여일시` | 권한 부여 시각(KST) |
+| `권한 만료일시 (NULL=무기한)` | 권한 만료 시각(KST). `NULL`이면 무기한 |
+| `현재 상태` | 현재 활성 여부 (`활성`/`비활성`) |
+
+## `connection_owners.sql`
+
+모든 활성 Connection에 지정된 Connection Owner를 조회합니다. Connection Owner는 일반 Connection 역할 테이블에서 이름으로 찾는 역할이 아니라, QueryPie 코드의 사전 정의 역할(`PredefinedRole.CONNECTION_OWNER`)입니다. 따라서 SQL에 현재 제품의 사전 정의 UUID를 내장해 두었으며 별도 변수 입력은 필요하지 않습니다.
+
+제품 버전에서 이 사전 정의 역할 UUID가 변경된 경우에만 SQL 상단 주석의 UUID를 새 값으로 바꾸세요. 현재 UUID는 `c3594b76-5d4e-11ec-b114-0ab3e84d3368`입니다.
+
+| 컬럼 | 설명 |
+| --- | --- |
+| `등록된 DB명` | Connection 이름 |
+| `등록된 Connection Owner` | Connection Owner 사용자 이름 목록. 여러 명이면 쉼표로 구분 |
+
+## `connection_owner_assignments.sql`
+
+Connection Owner를 찾기 위한 상세 조회입니다. Owner가 지정된 Connection만 반환하고, Connection마다 사용자 한 명당 한 행을 출력합니다. 사용자 식별자와 역할 배정 시각이 필요할 때 사용하세요. `connection_owners.sql`은 모든 Connection을 유지하면서 이름만 집계해 보는 용도입니다.
+
+| 컬럼 | 설명 |
+| --- | --- |
+| `Connection UUID` | Connection UUID |
+| `Connection Name` | Connection 이름 |
+| `User UUID` | Connection Owner 사용자 UUID |
+| `Login ID` | Connection Owner의 Login ID |
+| `User Name` | Connection Owner 사용자 이름 |
+| `Email` | Connection Owner 사용자 이메일 |
+| `Assigned At` | 해당 사용자에게 Connection Owner 역할이 배정된 시각(KST) |
+
+## 유의 사항
+
+- 역할·사용자·Connection의 삭제 여부 및 활성 상태는 각 SQL의 조건에 따라 다르게 적용됩니다. 목적에 맞는 SQL을 선택한 뒤 조건을 변경하세요.
+- 결과에는 사용자 이름, 이메일, 부서, 접근 권한 등 민감한 정보가 포함될 수 있으므로 추출 파일의 접근 권한을 관리하세요.

--- a/querypie-report/access_control/connection_accessible_users.sql
+++ b/querypie-report/access_control/connection_accessible_users.sql
@@ -1,0 +1,26 @@
+SET SESSION group_concat_max_len = 1000000;
+
+SELECT
+    cg.uuid AS connection_uuid,
+    cg.name AS connection_name,
+    COUNT(DISTINCT gu.user_uuid) AS assigned_user_count,
+    COALESCE(GROUP_CONCAT(DISTINCT CONCAT(gu.login_id, ' (', gu.user_name, ')') ORDER BY gu.login_id SEPARATOR ', '), '') AS assigned_users
+FROM querypie.cluster_groups cg
+LEFT JOIN (
+    SELECT DISTINCT crm.group_id, u.uuid AS user_uuid, u.login_id, u.name AS user_name
+    FROM querypie.cluster_role_maps crm
+    JOIN querypie.clusters c ON c.id = crm.cluster_id AND c.group_id = crm.group_id AND c.deleted = 0
+    JOIN querypie.users u ON u.id = crm.user_id AND u.type = 'USER' AND u.deleted = 0
+    WHERE crm.deleted = 0 AND crm.enabled = 1 AND crm.expired = 0 AND (crm.expiry_at IS NULL OR crm.expiry_at > UTC_TIMESTAMP())
+    UNION
+    SELECT DISTINCT crm.group_id, member.uuid AS user_uuid, member.login_id, member.name AS user_name
+    FROM querypie.cluster_role_maps crm
+    JOIN querypie.clusters c ON c.id = crm.cluster_id AND c.group_id = crm.group_id AND c.deleted = 0
+    JOIN querypie.users g ON g.id = crm.user_id AND g.type = 'GROUP' AND g.deleted = 0
+    JOIN querypie.user_group_users ugu ON ugu.user_group_uuid = g.uuid AND ugu.deleted = 0
+    JOIN querypie.users member ON member.uuid = ugu.user_uuid AND member.type = 'USER' AND member.deleted = 0
+    WHERE crm.deleted = 0 AND crm.enabled = 1 AND crm.expired = 0 AND (crm.expiry_at IS NULL OR crm.expiry_at > UTC_TIMESTAMP())
+) gu ON gu.group_id = cg.id
+WHERE cg.deleted = 0
+GROUP BY cg.uuid, cg.name
+ORDER BY cg.name;

--- a/querypie-report/access_control/connection_owner_assignments.sql
+++ b/querypie-report/access_control/connection_owner_assignments.sql
@@ -1,0 +1,22 @@
+-- Connection Owner는 QueryPie의 사전 정의 역할입니다.
+-- PredefinedRole.CONNECTION_OWNER UUID (현재 제품 기준):
+-- c3594b76-5d4e-11ec-b114-0ab3e84d3368
+-- Connection별 Owner를 사용자 단위로 한 행씩 조회합니다.
+
+SELECT
+    cg.uuid AS `Connection UUID`,
+    cg.name AS `Connection Name`,
+    u.uuid AS `User UUID`,
+    u.login_id AS `Login ID`,
+    u.name AS `User Name`,
+    u.email AS `Email`,
+    DATE_ADD(ur.created_at, INTERVAL 9 HOUR) AS `Assigned At`
+FROM querypie.cluster_groups cg
+INNER JOIN querypie.user_roles ur ON ur.object_type = 'CLUSTER_GROUP'
+    AND ur.object_uuid = cg.uuid
+    AND ur.role_uuid = 'c3594b76-5d4e-11ec-b114-0ab3e84d3368'
+    AND ur.deleted = 0
+INNER JOIN querypie.users u ON u.uuid = ur.user_uuid
+    AND u.deleted = 0
+WHERE cg.deleted = 0
+ORDER BY cg.name, u.name, u.login_id;

--- a/querypie-report/access_control/connection_owners.sql
+++ b/querypie-report/access_control/connection_owners.sql
@@ -1,0 +1,15 @@
+-- Connection Owner는 QueryPie의 사전 정의 역할입니다.
+-- PredefinedRole.CONNECTION_OWNER UUID (현재 제품 기준):
+-- c3594b76-5d4e-11ec-b114-0ab3e84d3368
+SELECT
+    cg.name AS `등록된 DB명`,
+    COALESCE(GROUP_CONCAT(DISTINCT u.name ORDER BY u.name SEPARATOR ', '), '') AS `등록된 Connection Owner`
+FROM querypie.cluster_groups cg
+LEFT JOIN querypie.user_roles ur ON ur.object_type = 'CLUSTER_GROUP'
+    AND ur.object_uuid = cg.uuid
+    AND ur.role_uuid = 'c3594b76-5d4e-11ec-b114-0ab3e84d3368'
+    AND ur.deleted = 0
+LEFT JOIN querypie.users u ON u.uuid = ur.user_uuid AND u.deleted = 0
+WHERE cg.deleted = 0
+GROUP BY cg.uuid, cg.name
+ORDER BY cg.name;

--- a/querypie-report/access_control/connection_privilege_grants.sql
+++ b/querypie-report/access_control/connection_privilege_grants.sql
@@ -1,0 +1,24 @@
+-- Input dates are KST. The end date includes the entire specified KST day.
+SET @start_kst = '2025-01-01 00:00:00';
+SET @end_kst = '2025-12-31 00:00:00';
+
+SELECT
+    cg.name AS `커넥션명`, cg.db_type AS `DB 유형`, c.host AS `호스트`, c.port AS `포트`,
+    u.login_id AS `로그인 ID`, u.name AS `사용자명`, u.email AS `이메일`, u.dept AS `부서`,
+    cr.name AS `역할명`, cr.privilege_vendor AS `권한 DB 유형`, cr.privilege_types AS `권한 목록 (DML/DCL/DDL)`,
+    CASE WHEN cr.can_import = 1 THEN 'Y' ELSE 'N' END AS `Can Import`,
+    CASE WHEN cr.can_export = 1 THEN 'Y' ELSE 'N' END AS `Can Export`,
+    CASE WHEN cr.can_copy_clipboard = 1 THEN 'Y' ELSE 'N' END AS `Can Copy to Clipboard`,
+    -- Schema 권한이 활성화된 환경에서만 사용합니다. 그렇지 않으면 이 컬럼을 제거하세요.
+    crm.schemas AS `스키마 범위 (NULL=전체)`,
+    DATE_ADD(crm.granted_at, INTERVAL 9 HOUR) AS `권한 부여일시`,
+    DATE_ADD(crm.expiry_at, INTERVAL 9 HOUR) AS `권한 만료일시 (NULL=무기한)`,
+    CASE WHEN crm.enabled = 1 THEN '활성' ELSE '비활성' END AS `현재 상태`
+FROM querypie.cluster_role_maps crm
+JOIN querypie.users u ON u.id = crm.user_id AND u.deleted = 0
+JOIN querypie.cluster_roles cr ON cr.id = crm.role_id AND cr.deleted = 0
+LEFT JOIN querypie.clusters c ON c.id = crm.cluster_id AND c.deleted = 0
+JOIN querypie.cluster_groups cg ON cg.id = crm.group_id AND cg.deleted = 0
+WHERE crm.granted_at >= DATE_SUB(@start_kst, INTERVAL 9 HOUR)
+  AND crm.granted_at < DATE_SUB(DATE_ADD(@end_kst, INTERVAL 1 DAY), INTERVAL 9 HOUR)
+ORDER BY cg.name, c.host, u.login_id, crm.granted_at DESC;

--- a/querypie-report/access_control/role_grants_as_of_date.sql
+++ b/querypie-report/access_control/role_grants_as_of_date.sql
@@ -1,0 +1,22 @@
+SET @as_of_date = '2026-03-31';
+-- Explicitly match cluster_groups.name's legacy utf8mb4 collation.
+SET @connection_name = CONVERT('connection-name' USING utf8mb4) COLLATE utf8mb4_general_ci;
+
+SELECT
+    u.type AS `User Type`, u.name AS `User Name`, cg.name AS `Connection Name`, c.host AS `DB Host`,
+    CASE c.repl_type WHEN 'MASTER' THEN 'PRIMARY' WHEN 'SLAVE' THEN 'SECONDARY' WHEN 'SINGLE' THEN 'SINGLE' ELSE '' END AS `Replication Type`,
+    cr.name AS `Role Name`,
+    CASE WHEN crm.enabled = 0 THEN 'Deactivated' WHEN crm.enabled = 1 THEN 'Active' WHEN crm.expired = 1 THEN 'Expired' ELSE '' END AS `Status`,
+    DATE_ADD(crm.granted_at, INTERVAL 9 HOUR) AS `Granted At`, COALESCE(DATE_ADD(crm.expiry_at, INTERVAL 9 HOUR), '') AS `Expiration At`,
+    COALESCE(DATE_ADD(crm.renew_at, INTERVAL 9 HOUR), '') AS `Renewed At`,
+    COALESCE(DATE_ADD(crm.last_access_at, INTERVAL 9 HOUR), '') AS `Last Access At`
+FROM querypie.cluster_role_maps crm
+LEFT JOIN querypie.users u ON u.id = crm.user_id
+LEFT JOIN querypie.clusters c ON c.id = crm.cluster_id
+LEFT JOIN querypie.cluster_groups cg ON cg.id = c.group_id
+LEFT JOIN querypie.cluster_roles cr ON cr.id = crm.role_id
+WHERE crm.deleted = 0 AND u.deleted = 0
+  AND @as_of_date BETWEEN DATE(DATE_ADD(crm.granted_at, INTERVAL 9 HOUR))
+      AND COALESCE(DATE(DATE_ADD(crm.expiry_at, INTERVAL 9 HOUR)), '9999-12-31')
+  AND cg.name = @connection_name
+ORDER BY crm.granted_at DESC;

--- a/querypie-report/activity_log/README.md
+++ b/querypie-report/activity_log/README.md
@@ -1,0 +1,29 @@
+# Activity Log 변경 전·후 조회
+
+- `activity_log_before_after.sql`: Activity Log의 `deltas` JSON을 펼쳐 변경 전·후 값을 조회합니다.
+
+MySQL 8.0 이상의 `JSON_TABLE`을 사용합니다. SQL 상단의 기간 변수와 결과의 `action_at_kst`는 모두 KST 기준입니다. 선택 필터는 주석 처리된 조건에서 설정합니다. 변경 전·후 값은 민감할 수 있으므로 결과 파일 접근 권한을 관리하세요.
+
+## 결과 컬럼
+
+| 순서 | 컬럼 | 설명 |
+| ---: | --- | --- |
+| 1 | `event_id` | Activity Log ID |
+| 2 | `event_uuid` | Activity Log UUID |
+| 3 | `action_at_kst` | 이벤트 발생 시각(KST) |
+| 4 | `event_type` | 이벤트 유형(`action_type`) |
+| 5 | `target_type` | 변경 대상 유형 |
+| 6 | `target_name` | 변경 대상 이름 |
+| 7 | `target_uuid` | 변경 대상 UUID |
+| 8 | `client_ip` | 이벤트를 발생시킨 클라이언트 IP |
+| 9 | `actor_name` | 이벤트 수행자 이름 |
+| 10 | `actor_email` | 이벤트 수행자 이메일 |
+| 11 | `actor_dept` | 이벤트 수행자 부서 |
+| 12 | `key` | 변경된 속성의 내부 키 |
+| 13 | `label` | 변경된 속성의 표시 이름 |
+| 14 | `before` | 변경 전 값 |
+| 15 | `after` | 변경 후 값 |
+| 16 | `has_changed` | 실제 값 변경 여부 (`1`/`0`) |
+| 17 | `is_storable` | 해당 변경값의 저장 가능 여부 (`1`/`0`) |
+
+`deltas` 배열의 항목마다 한 행이 생성됩니다. 따라서 하나의 Activity Log가 여러 속성을 변경한 경우 같은 `event_id`가 여러 행에 반복될 수 있습니다.

--- a/querypie-report/activity_log/activity_log_before_after.sql
+++ b/querypie-report/activity_log/activity_log_before_after.sql
@@ -1,0 +1,23 @@
+-- MySQL 8.0+ required for JSON_TABLE. Input and output dates use KST.
+SET @start_kst = '2025-01-01 00:00:00';
+SET @end_kst = '2025-12-31 23:59:59';
+
+SELECT
+    al.id AS event_id, al.uuid AS event_uuid,
+    DATE_FORMAT(DATE_ADD(al.action_at, INTERVAL 9 HOUR), '%Y-%m-%d %H:%i:%s') AS action_at_kst,
+    al.action_type AS event_type, al.target_type AS target_type, al.target_name AS target_name,
+    al.target_uuid AS target_uuid, al.client_ip AS client_ip,
+    u.name AS actor_name, u.email AS actor_email, u.dept AS actor_dept,
+    d.`key`, d.`label`, d.`before`, d.`after`, d.has_changed, d.is_storable
+FROM querypie_log.l_activity_logs al
+LEFT JOIN querypie.users u ON u.id = al.action_by
+JOIN JSON_TABLE(
+    COALESCE(al.deltas, '[]'), '$[*]' COLUMNS (
+        `key` VARCHAR(255) PATH '$.key', `label` VARCHAR(255) PATH '$.label',
+        `before` TEXT PATH '$.before', `after` TEXT PATH '$.after',
+        has_changed TINYINT(1) PATH '$.hasChanged', is_storable TINYINT(1) PATH '$.isStorable'
+    )
+) AS d
+WHERE al.action_at >= DATE_SUB(@start_kst, INTERVAL 9 HOUR)
+  AND al.action_at <= DATE_SUB(@end_kst, INTERVAL 9 HOUR)
+ORDER BY al.action_at DESC, al.id;

--- a/querypie-report/ledger_policy/README.md
+++ b/querypie-report/ledger_policy/README.md
@@ -1,0 +1,20 @@
+# Ledger 정책 테이블 조회
+
+- `ledger_policy_tables.sql`: DB 유형과 관계없이 활성 Ledger 정책에 등록된 Connection, Database, Schema, Table, Workflow Rule 목록
+
+`cluster_groups`의 DB 유형을 제한하지 않으므로 MongoDB를 포함한 모든 Connection 유형의 활성 Ledger 정책 대상을 출력합니다.
+
+App DB(`querypie`) 읽기 권한이 필요합니다.
+
+## 결과 컬럼
+
+| 순서 | 컬럼 | 설명 |
+| ---: | --- | --- |
+| 1 | `Connection 이름` | Ledger 정책이 연결된 Connection 이름 (`cluster_groups.name`) |
+| 2 | `Connection Uuid` | Ledger 정책이 연결된 Connection UUID (`cluster_groups.uuid`) |
+| 3 | `Database Name` | Ledger Policy에 설정된 Database 이름 (`ledger_policies.database_name`) |
+| 4 | `Schema Name` | Ledger 정책 테이블의 Schema 이름 (`ledger_policy_tables.schema_name`) |
+| 5 | `Table Name` | Ledger 정책에 등록된 Table 또는 Collection 이름 (`ledger_policy_tables.table_name`) |
+| 6 | `Workflow Rule Name` | 해당 Ledger 정책 테이블에 연결된 Workflow Rule 이름 (`workflow_rules.name`) |
+
+삭제되지 않았고 활성화된 Ledger 정책 및 정책 테이블만 출력합니다. 결과는 Connection, Database, Table 이름 순으로 정렬됩니다.

--- a/querypie-report/ledger_policy/ledger_policy_tables.sql
+++ b/querypie-report/ledger_policy/ledger_policy_tables.sql
@@ -1,0 +1,15 @@
+-- Active Ledger policy targets across all DB connection types.
+SELECT
+    cg.name AS `Connection 이름`,
+    cg.uuid AS `Connection Uuid`,
+    lp.database_name AS `Database Name`,
+    lpt.schema_name AS `Schema Name`,
+    lpt.table_name AS `Table Name`,
+    rule.name AS `Workflow Rule Name`
+FROM querypie.ledger_policy_tables lpt
+JOIN querypie.ledger_policies lp ON lp.policy_uuid = lpt.policy_uuid AND lp.deleted = 0
+JOIN querypie.policies p ON p.uuid = lp.policy_uuid AND p.type = 'LEDGER' AND p.enabled = 1 AND p.deleted = 0
+JOIN querypie.cluster_groups cg ON cg.uuid = p.object_uuid
+INNER JOIN querypie.workflow_rules rule ON rule.uuid = lpt.workflow_rule_uuid
+WHERE lpt.deleted = 0
+ORDER BY cg.name, lp.database_name, lpt.table_name;

--- a/querypie-report/ledger_workflow_dml_count/README.md
+++ b/querypie-report/ledger_workflow_dml_count/README.md
@@ -1,0 +1,61 @@
+# Ledger 테이블 DML 건수 조회
+
+[ledger_table_dml_count.sql](ledger_table_dml_count.sql)은 활성 Ledger 정책 테이블별로 지정 기간에 수행된 DML Query Audit 건수를 조회합니다.
+
+## 대상 데이터
+
+- App DB (`querypie`)
+  - `ledger_policy_tables`, `ledger_policies`, `policies`
+  - `cluster_groups`, `workflow_rules`
+- Log DB (`querypie_log`)
+  - `l_query_execution_logs`
+  - `l_db_connection_snapshots`
+  - `l_query_execution_log_details`
+
+조회 대상은 숨김 처리되지 않았고(`hidden = 0`), Ledger로 기록됐으며(`ledger = 1`), 성공 상태(`state = 1`)이고, 대상 객체가 있는 Query Audit입니다.
+
+## 기간 설정
+
+SQL 상단의 변수를 KST 기준으로 수정합니다.
+
+```sql
+SET @start_kst = '2025-01-01 00:00:00';
+SET @end_kst   = '2026-01-01 00:00:00';
+SET @tz_offset_hour = 9;
+```
+
+- 시작 시각은 포함됩니다.
+- 종료 시각은 포함되지 않습니다.
+- Query Audit의 UTC `executed_at`과 비교할 때 KST 9시간을 차감합니다.
+
+## 실행 예시
+
+App DB와 Log DB를 모두 조회할 수 있는 MySQL 계정으로 실행합니다.
+
+```bash
+mysql -h <host> -P <port> -u <user> -p < ledger_table_dml_count.sql
+```
+
+데이터가 큰 기간에는 대상 객체 문자열을 재귀적으로 분리하므로, 기간을 나누어 실행하는 것을 권장합니다.
+
+## 조회 방식
+
+1. 활성 Ledger 정책에서 Connection / Database / Schema / Table 목록을 읽습니다.
+2. 테이블 표기 방식 차이를 고려해 `table`, `database.table`, `schema.table`, `database.schema.table` 후보를 만듭니다.
+3. Ledger Query Audit의 `target_object_names`를 테이블 단위로 분리하고 식별자 따옴표를 제거합니다.
+4. Connection Group, 대상 테이블, 필요한 경우 Database까지 일치시키고 DML Query Audit을 집계합니다.
+
+집계하는 DML `query_type`은 `3, 4, 5, 6, 7, 8`입니다. Query Audit 한 건은 같은 Ledger 테이블에 한 번만 집계됩니다.
+
+## 결과 컬럼
+
+| 컬럼 | 설명 |
+| --- | --- |
+| `Connection` | Ledger 정책이 적용된 Connection 이름 |
+| `Database` | Ledger 정책 Database 이름 |
+| `Schema` | Ledger 정책 Schema 이름 |
+| `Table` | Ledger 정책 테이블 이름 |
+| `RuleName` | 연결된 Workflow Rule 이름 |
+| `DML 개수` | 기간 내 해당 Ledger 테이블에 매칭된 DML Query Audit 건수 |
+
+Ledger 정책 테이블은 조회 기간에 매칭되는 DML이 없어도 결과에 포함되며, 이 경우 `DML 개수`는 `0`입니다.

--- a/querypie-report/ledger_workflow_dml_count/ledger_table_dml_count.sql
+++ b/querypie-report/ledger_workflow_dml_count/ledger_table_dml_count.sql
@@ -1,0 +1,154 @@
+SET @start_kst = '2025-01-01 00:00:00';
+SET @end_kst   = '2026-01-01 00:00:00';
+SET @tz_offset_hour = 9;
+
+WITH RECURSIVE
+ledger_targets AS (
+    SELECT
+        cg.uuid          AS cluster_group_uuid,
+        cg.name          AS connection_name,
+        lp.database_name AS database_name,
+        lpt.schema_name  AS schema_name,
+        lpt.table_name   AS table_name,
+        wr.name          AS rule_name
+    FROM querypie.ledger_policy_tables lpt
+    JOIN querypie.ledger_policies lp
+      ON lp.policy_uuid = lpt.policy_uuid
+     AND lp.deleted = 0
+    JOIN querypie.policies p
+      ON p.uuid = lpt.policy_uuid
+     AND p.deleted = 0
+    JOIN querypie.cluster_groups cg
+      ON cg.uuid = p.object_uuid
+    JOIN querypie.workflow_rules wr
+      ON wr.uuid = lpt.workflow_rule_uuid
+     AND wr.deleted = 0
+    WHERE lpt.deleted = 0
+),
+ledger_target_candidates AS (
+    SELECT
+        lt.*,
+        lt.table_name AS candidate_object_name,
+        1 AS requires_snapshot_db_match
+    FROM ledger_targets lt
+
+    UNION ALL
+
+    SELECT
+        lt.*,
+        CONCAT(lt.database_name, '.', lt.table_name) AS candidate_object_name,
+        0 AS requires_snapshot_db_match
+    FROM ledger_targets lt
+
+    UNION ALL
+
+    SELECT
+        lt.*,
+        CONCAT(lt.schema_name, '.', lt.table_name) AS candidate_object_name,
+        1 AS requires_snapshot_db_match
+    FROM ledger_targets lt
+    WHERE lt.schema_name IS NOT NULL
+
+    UNION ALL
+
+    SELECT
+        lt.*,
+        CONCAT(lt.database_name, '.', lt.schema_name, '.', lt.table_name) AS candidate_object_name,
+        0 AS requires_snapshot_db_match
+    FROM ledger_targets lt
+    WHERE lt.schema_name IS NOT NULL
+),
+audit_base AS (
+    SELECT
+        l.uuid AS log_uuid,
+        l.query_type,
+        c.cluster_group_uuid,
+        c.db_name,
+        CAST(COALESCE(d.target_object_names, '') AS CHAR(4000)) AS target_object_names
+    FROM querypie_log.l_query_execution_logs l
+    JOIN querypie_log.l_db_connection_snapshots c
+      ON c.id = l.db_connection_snapshot_id
+    LEFT JOIN querypie_log.l_query_execution_log_details d
+      ON d.id = l.id
+    WHERE l.hidden = 0
+      AND l.ledger = 1
+      AND l.state = 1
+      AND l.query_target_object_count > 0
+      AND l.executed_at >= DATE_SUB(@start_kst, INTERVAL @tz_offset_hour HOUR)
+      AND l.executed_at <  DATE_SUB(@end_kst,   INTERVAL @tz_offset_hour HOUR)
+      AND COALESCE(d.target_object_names, '') <> ''
+),
+split_targets AS (
+    SELECT
+        log_uuid,
+        query_type,
+        cluster_group_uuid,
+        db_name,
+        CAST(TRIM(SUBSTRING_INDEX(target_object_names, ',', 1)) AS CHAR(1000)) AS object_name,
+        CAST(
+            CASE
+                WHEN LOCATE(',', target_object_names) > 0
+                THEN SUBSTRING(target_object_names, LOCATE(',', target_object_names) + 1)
+                ELSE ''
+            END AS CHAR(4000)
+        ) AS rest
+    FROM audit_base
+
+    UNION ALL
+
+    SELECT
+        log_uuid,
+        query_type,
+        cluster_group_uuid,
+        db_name,
+        CAST(TRIM(SUBSTRING_INDEX(rest, ',', 1)) AS CHAR(1000)) AS object_name,
+        CAST(
+            CASE
+                WHEN LOCATE(',', rest) > 0
+                THEN SUBSTRING(rest, LOCATE(',', rest) + 1)
+                ELSE ''
+            END AS CHAR(4000)
+        ) AS rest
+    FROM split_targets
+    WHERE rest <> ''
+),
+normalized_targets AS (
+    SELECT DISTINCT
+        log_uuid,
+        query_type,
+        cluster_group_uuid,
+        db_name,
+        TRIM(REPLACE(REPLACE(REPLACE(object_name, '`', ''), '"', ''), '''', '')) AS object_name
+    FROM split_targets
+    WHERE object_name <> ''
+)
+SELECT
+    ltc.connection_name AS `Connection`,
+    ltc.database_name   AS `Database`,
+    ltc.schema_name     AS `Schema`,
+    ltc.table_name      AS `Table`,
+    ltc.rule_name       AS `RuleName`,
+    COUNT(DISTINCT CASE WHEN nt.query_type IN (3, 4, 5, 6, 7, 8) THEN nt.log_uuid END) AS `DML 개수`
+FROM ledger_target_candidates ltc
+LEFT JOIN normalized_targets nt
+  ON nt.cluster_group_uuid COLLATE utf8mb4_general_ci
+   = ltc.cluster_group_uuid COLLATE utf8mb4_general_ci
+ AND nt.object_name COLLATE utf8mb4_general_ci
+   = ltc.candidate_object_name COLLATE utf8mb4_general_ci
+ AND (
+        ltc.requires_snapshot_db_match = 0
+        OR nt.db_name COLLATE utf8mb4_general_ci
+         = ltc.database_name COLLATE utf8mb4_general_ci
+     )
+GROUP BY
+    ltc.connection_name,
+    ltc.database_name,
+    ltc.schema_name,
+    ltc.table_name,
+    ltc.rule_name
+ORDER BY
+    ltc.connection_name,
+    ltc.database_name,
+    ltc.schema_name,
+    ltc.table_name,
+    ltc.rule_name;

--- a/querypie-report/query_audit/README.md
+++ b/querypie-report/query_audit/README.md
@@ -1,0 +1,64 @@
+# Query Audit 조회
+
+성공한 Query Audit 실행 이력을 사용자, Connection, 권한, 실행 SQL, 처리량 및 Ledger 표시와 함께 상세 조회하는 SQL 모음입니다. 모든 SQL은 읽기 전용이며 Log DB(`querypie_log`)에 대한 조회 권한이 필요합니다.
+
+## 파일 선택 및 실행 방법
+
+| 파일 | 사용 목적 | 주요 입력 |
+| --- | --- | --- |
+| `query_audit_success_detail.sql` | 기간 내 성공한 Query Audit 상세 실행 이력 | 시작 시각, 종료 시각(KST) |
+
+SQL 상단의 기간 변수를 수정한 뒤 실행합니다.
+
+```sql
+SET @start_kst = '2025-06-01 00:00:00';
+SET @end_kst = '2025-06-20 00:00:00';
+```
+
+입력값은 KST 기준입니다. SQL은 `executed_at` 저장값과 비교할 때 9시간을 빼고, 출력할 때는 9시간을 더해 KST로 표시합니다. 시작 시각은 포함하고 종료 시각은 미포함이므로, 하루 전체를 조회하려면 종료값에 다음 날 00:00:00을 넣으세요.
+
+예를 들어 2025-06-01 하루만 조회하려면 다음처럼 설정합니다.
+
+```sql
+SET @start_kst = '2025-06-01 00:00:00';
+SET @end_kst = '2025-06-02 00:00:00';
+```
+
+## `query_audit_success_detail.sql`
+
+`l_query_execution_logs.state = 1`인 성공 실행만 반환합니다. Query Audit 기본 로그에 상세 로그, DB Connection 스냅샷, 사용자 스냅샷, Connection 역할 스냅샷을 결합합니다. 로그 ID별 한 행을 보장하기 위해 `GROUP BY l.id`와 `ANY_VALUE()`를 사용합니다.
+
+| 컬럼 | 설명 |
+| --- | --- |
+| `No` | Query Audit 로그 ID |
+| `Executed At` | 실행 시각(KST) |
+| `Result` | 실행 결과. 이 SQL은 성공(`SUCCESS`) 행만 조회 |
+| `Name` | 실행 사용자 이름(사용자 스냅샷 기준) |
+| `Email` | 실행 사용자 이메일(사용자 스냅샷 기준) |
+| `Action Type` | 수행 동작 유형(접속, SQL 실행, 데이터 Export/Import, 복사 등) |
+| `Connection Name` | 실행에 사용한 Connection 이름 |
+| `Database Type` | 대상 DB 유형 |
+| `Privilege Name` | 실행 시점에 적용된 Connection 역할 이름 |
+| `Client IP` | 실행 클라이언트 IP 주소 |
+| `Replication Type` | 대상 Connection의 복제 유형 |
+| `DB Host` | 대상 DB 호스트 |
+| `DB Name` | 대상 DB 이름 |
+| `DB User` | 실제 DB 접속 사용자 |
+| `Table(s)` | SQL에서 식별된 대상 테이블 이름 목록 |
+| `SQL Type` | SQL 구문 유형(`Select`, `Insert`, `Update`, `Delete`, `DDL` 등) |
+| `Query` | 실행한 SQL 전문 |
+| `Time(ms)` | 실행 처리 시간(밀리초) |
+| `Rows` | 처리된 레코드 수. 값이 없으면 빈 문자열 |
+| `Data Size` | 처리된 데이터 크기. 값이 없으면 빈 문자열 |
+| `Client Name` | 실행 클라이언트 이름. 값이 없으면 빈 문자열 |
+| `Error Message` | 상세 로그의 오류 메시지. 성공 실행에서는 일반적으로 빈 값 |
+| `Execution Reason` | 실행 사유 또는 작업 코멘트 |
+| `Prevented` | 정책에 의해 차단되었는지 여부(`Not Prevented`/`Prevented`) |
+| `Label` | Ledger 표시 여부(`Normal`/`Ledger`) |
+| `Executed From` | 실행 유입 경로(Web Editor, Proxy, SQL Request, SQL Job, SQL Export Request 등) |
+
+## 유의 사항
+
+- 이 SQL은 실패·중지·차단된 Query Audit 행을 제외합니다. 전체 결과 상태가 필요하면 `WHERE l.state = 1` 조건을 조정하세요.
+- `Query`, `Execution Reason`, `Table(s)`, 사용자·Connection 정보에는 민감한 정보가 포함될 수 있습니다. 추출 결과의 열람 및 보관 권한을 관리하세요.
+- QueryPie Log DB의 `executed_at`은 UTC 저장값으로 처리하며, 이 SQL은 KST 입력값을 UTC로 변환해 비교하고 KST로 출력합니다.

--- a/querypie-report/query_audit/query_audit_success_detail.sql
+++ b/querypie-report/query_audit/query_audit_success_detail.sql
@@ -1,0 +1,41 @@
+-- Successful Query Audit detail report. Dates are KST.
+SET @start_kst = '2025-06-01 00:00:00';
+SET @end_kst = '2025-06-20 00:00:00';
+
+SELECT
+    l.id AS `No`,
+    ANY_VALUE(DATE_ADD(l.executed_at, INTERVAL 9 HOUR)) AS `Executed At`,
+    ANY_VALUE(CASE l.state WHEN 1 THEN 'SUCCESS' WHEN 2 THEN 'FAILURE' WHEN 3 THEN 'STOPPED' WHEN 5 THEN 'RUNNING' WHEN 6 THEN 'ABORTED' ELSE 'unknown' END) AS `Result`,
+    ANY_VALUE(u.user_name) AS `Name`,
+    ANY_VALUE(u.user_email) AS `Email`,
+    ANY_VALUE(CASE l.action_type WHEN 0 THEN 'Connection' WHEN 1 THEN 'SQL Execution' WHEN 2 THEN 'Export Data' WHEN 3 THEN 'Export Schema' WHEN 4 THEN 'Import Data' WHEN 5 THEN 'Import Schema' WHEN 6 THEN 'Copy Clipboard' ELSE 'unknown' END) AS `Action Type`,
+    ANY_VALUE(c.cluster_group_name) AS `Connection Name`,
+    ANY_VALUE(c.db_type) AS `Database Type`,
+    ANY_VALUE(r.cluster_role_name) AS `Privilege Name`,
+    ANY_VALUE(l.client_ip) AS `Client IP`,
+    ANY_VALUE(c.cluster_repl_type) AS `Replication Type`,
+    ANY_VALUE(c.db_host) AS `DB Host`,
+    ANY_VALUE(c.db_name) AS `DB Name`,
+    ANY_VALUE(l.db_user) AS `DB User`,
+    ANY_VALUE(COALESCE(ld.target_object_names, '')) AS `Table(s)`,
+    ANY_VALUE(CASE l.query_type WHEN 0 THEN 'Unknown' WHEN 1 THEN 'With' WHEN 2 THEN 'Select' WHEN 3 THEN 'Insert' WHEN 4 THEN 'Upsert' WHEN 5 THEN 'Replace' WHEN 6 THEN 'Update' WHEN 7 THEN 'Delete' WHEN 8 THEN 'MergeInto' WHEN 9 THEN 'Create' WHEN 10 THEN 'Alter' WHEN 11 THEN 'Drop' WHEN 12 THEN 'Rename' WHEN 13 THEN 'Truncate' WHEN 14 THEN 'Grant' WHEN 15 THEN 'Revoke' WHEN 16 THEN 'Commit' WHEN 17 THEN 'Rollback' WHEN 18 THEN 'SavePoint' WHEN 19 THEN 'Prepare' WHEN 20 THEN 'DropPrepare' WHEN 21 THEN 'Execute' WHEN 22 THEN 'Delimiter' WHEN 23 THEN 'Call' WHEN 24 THEN 'Explain' WHEN 25 THEN 'Use' WHEN 26 THEN 'Show' WHEN 27 THEN 'Describe' WHEN 28 THEN 'Set' WHEN 29 THEN 'Begin' WHEN 30 THEN 'Comment' WHEN 31 THEN 'Trivia' ELSE 'unknown' END) AS `SQL Type`,
+    ANY_VALUE(l.query_text) AS `Query`,
+    ANY_VALUE(l.processing_millis) AS `Time(ms)`,
+    ANY_VALUE(COALESCE(l.processed_record_count, '')) AS `Rows`,
+    ANY_VALUE(COALESCE(l.processed_record_byte_count, '')) AS `Data Size`,
+    ANY_VALUE(COALESCE(l.client_name, '')) AS `Client Name`,
+    ANY_VALUE(COALESCE(ld.error_message, '')) AS `Error Message`,
+    ANY_VALUE(COALESCE(ld.action_comment, '')) AS `Execution Reason`,
+    ANY_VALUE(CASE l.prevented WHEN 0 THEN 'Not Prevented' WHEN 1 THEN 'Prevented' END) AS `Prevented`,
+    ANY_VALUE(CASE l.ledger WHEN 0 THEN 'Normal' WHEN 1 THEN 'Ledger' END) AS `Label`,
+    ANY_VALUE(CASE l.action_origin_type WHEN 1 THEN 'Web Editor' WHEN 2 THEN 'Proxy' WHEN 3 THEN 'SQL Request' WHEN 4 THEN 'SQL Job' WHEN 5 THEN 'SQL Export Request' ELSE '' END) AS `Executed From`
+FROM querypie_log.l_query_execution_logs l
+LEFT JOIN querypie_log.l_query_execution_log_details ld ON ld.id = l.id
+LEFT JOIN querypie_log.l_db_connection_snapshots c ON c.id = l.db_connection_snapshot_id
+LEFT JOIN querypie_log.l_user_snapshots u ON u.id = l.user_snapshot_id
+LEFT JOIN querypie_log.l_cluster_role_snapshots r ON r.id = ld.cluster_role_snapshot_ids
+WHERE l.state = 1
+  AND l.executed_at >= DATE_SUB(@start_kst, INTERVAL 9 HOUR)
+  AND l.executed_at < DATE_SUB(@end_kst, INTERVAL 9 HOUR)
+GROUP BY l.id
+ORDER BY l.id DESC;

--- a/querypie-report/user_history/README.md
+++ b/querypie-report/user_history/README.md
@@ -1,0 +1,96 @@
+# 사용자 이력 조회
+
+사용자 생성·삭제, 계정 잠김·해제·만료 및 로그인 성공·실패 이력을 조회하는 SQL 모음입니다. 모든 SQL은 읽기 전용입니다.
+
+## 파일 선택
+
+| 파일 | 사용 목적 | 필요 DB | 주요 입력 |
+| --- | --- | --- | --- |
+| `user_history_1.sql` | 사용자 생성·삭제와 계정 잠김·해제·만료를 하나의 시간순 결과로 조회 | App DB, Log DB | 없음 |
+| `user_login_success.sql` | 성공한 로그인 이력 상세 조회 | Log DB | 시작 시각, 종료 시각(KST) |
+| `user_login_failure.sql` | 실패한 로그인 이력 조회 | Log DB | 시작 시각, 종료 시각(KST) |
+
+## `user_history_1.sql`
+
+App DB(`querypie`)의 현재 사용자 정보와 Log DB(`querypie_log`)의 Activity Log·User Auth Log를 결합해 주요 사용자 상태 변경 이력을 시간순으로 출력합니다.
+
+### 포함 이벤트
+
+| 원본 이벤트 | 출력 이벤트 | 출처 |
+| --- | --- | --- |
+| `USER_CREATED` | 사용자 생성 | Activity Log |
+| `USER_DELETED` | 사용자 삭제 | Activity Log |
+| `LOCKED` | 계정 잠김 | User Auth Log |
+| `LOCKED_MANUALLY` | 계정 수동 잠김 | User Auth Log |
+| `UNLOCK` | 잠김 해제 | User Auth Log |
+| `EXPIRED` | 만료됨 | User Auth Log |
+
+기간 조건이 없으므로 전체 이력을 반환합니다. 데이터가 많은 운영 환경에서는 두 CTE(`user_activity_logs`, `user_auth_logs`)의 `WHERE` 절에 기간 조건을 추가해 사용하세요.
+
+| 컬럼 | 설명 |
+| --- | --- |
+| `시간` | 이벤트 발생 시각(KST) |
+| `이벤트` | 사람이 읽기 쉬운 이벤트 이름 |
+| `사용자 Id or Name` | 대상 사용자의 Login ID를 우선 사용하고, 없으면 이름 사용 |
+| `행위자 Id` | 이벤트를 수행한 사용자의 Login ID |
+| `사유` | 잠김·잠김 해제·만료 사유 또는 로그 메시지 |
+| `사용자생성일` | 대상 사용자의 생성 시각(KST) |
+| `마지막로그인` | 대상 사용자의 마지막 로그인 시각(KST) |
+| `Unlock시간` | 대상 사용자의 잠김 해제 시각(KST) |
+
+## `user_login_success.sql`
+
+`action_type = 'LOGIN'` 및 `error = 0`인 성공 로그인 이력을 조회합니다. 입력 기간은 KST 기준이며, SQL은 UTC 로그 시각과 비교하기 위해 9시간을 빼서 비교합니다. 시작 시각은 포함하고 종료 시각은 미포함입니다.
+
+```sql
+SET @start_kst = '2025-01-01 00:00:00';
+SET @end_kst = '2025-02-01 00:00:00';
+```
+
+`SELECT *`를 사용하지 않고 현재 QueryPie의 User Auth Log 컬럼을 명시적으로 선택하도록 정리했습니다. 제품 버전에서 Log DB 스키마가 달라진 경우에는 컬럼 목록을 확인하세요.
+
+| 컬럼 | 설명 |
+| --- | --- |
+| `id` | User Auth Log ID |
+| `hash` | 로그 무결성 검증용 해시 |
+| `user_id` | 로그인 대상 사용자의 내부 ID |
+| `user_login_id` | 로그인 대상 사용자의 Login ID |
+| `user_name` | 로그인 대상 사용자 이름 |
+| `user_email` | 로그인 대상 사용자 이메일 |
+| `action_type` | 인증 동작 유형. 이 SQL에서는 `LOGIN` |
+| `acted_at_kst` | 로그인 처리 시각(KST) |
+| `error` | 인증 실패 여부. 이 SQL에서는 `0` |
+| `message` | 인증 처리 메시지 |
+| `client_ip` | 로그인 클라이언트 IP 주소 |
+| `host_name` | 로그인 클라이언트 호스트 이름 |
+| `actor_user_id` | 행위자 사용자 내부 ID. 일반 로그인에서는 비어 있을 수 있음 |
+| `actor_user_name` | 행위자 사용자 이름. 일반 로그인에서는 비어 있을 수 있음 |
+| `created_by` | 로그 생성 주체의 내부 ID |
+| `created_at_kst` | 로그 레코드 생성 시각(KST) |
+
+## `user_login_failure.sql`
+
+`action_type = 'LOGIN'` 및 `error = 1`인 로그인 실패 이력을 조회합니다. `created_at`을 기간 조건으로 사용하며, 시작 시각은 포함하고 종료 시각은 미포함입니다.
+
+```sql
+SET @start_kst = '2025-01-01 00:00:00';
+SET @end_kst = '2025-02-01 00:00:00';
+```
+
+입력 시각은 KST 기준이며, SQL은 UTC로 저장된 `created_at`과 비교할 때 9시간을 뺍니다. `acted_at`은 KST로 변환해 출력합니다. 별도 `ORDER BY`가 없으므로 결과 순서가 필요하면 `ORDER BY acted_at` 등을 추가하세요.
+
+| 컬럼 | 설명 |
+| --- | --- |
+| `acted_at_kst` | 로그인 시도 처리 시각(KST) |
+| `user_login_id` | 로그인 시도한 Login ID |
+| `user_name` | 로그인 시도 사용자 이름 |
+| `user_email` | 로그인 시도 사용자 이메일 |
+| `client_ip` | 로그인 시도 클라이언트 IP 주소 |
+| `host_name` | 로그인 시도 클라이언트 호스트 이름 |
+| `message` | 로그인 실패 사유 또는 인증 메시지 |
+
+## 유의 사항
+
+- 결과에는 사용자 식별자, 이메일, IP 주소, 인증 관련 메시지가 포함될 수 있습니다. 추출 파일의 열람·보관 권한을 관리하세요.
+- 삭제된 사용자는 App DB의 `users` 레코드가 없어도 로그에 남은 이름·Login ID 범위에서 표시됩니다.
+- 모든 SQL은 UTC 저장 시각을 기준으로 KST 입력값을 변환해 비교하며, 출력 시각도 KST로 표시합니다.

--- a/querypie-report/user_history/user_history_1.sql
+++ b/querypie-report/user_history/user_history_1.sql
@@ -1,0 +1,98 @@
+WITH user_activity_logs AS (
+    SELECT
+        al.action_at AS event_time,
+        CASE al.action_type
+            WHEN 'USER_CREATED' THEN '사용자 생성'
+            WHEN 'USER_DELETED' THEN '사용자 삭제'
+            ELSE al.action_type
+        END AS event_name,
+        al.action_type AS raw_event_type,
+
+        target_user.login_id AS target_login_id,
+        COALESCE(target_user.name, al.target_name) AS target_user_name,
+        target_user.email AS target_user_email,
+        target_user.status AS current_user_status,
+        target_user.created_at AS target_user_created_at,
+        target_user.last_login_at AS target_user_last_login_at,
+        target_user.unlocked_at AS target_user_unlocked_at,
+
+        actor.login_id AS actor_login_id,
+        actor.name AS actor_name,
+
+        NULL AS reason,
+        al.client_ip,
+        al.deltas AS detail
+    FROM querypie_log.l_activity_logs al
+    LEFT JOIN querypie.users target_user
+      ON target_user.uuid = al.target_uuid
+    LEFT JOIN querypie.users actor
+      ON actor.id = al.action_by
+    WHERE al.target_type = 'USER'
+      AND al.action_type IN (
+          'USER_CREATED',
+          'USER_DELETED'
+      )
+),
+user_auth_logs AS (
+    SELECT
+        ual.acted_at AS event_time,
+        CASE ual.action_type
+            WHEN 'LOCKED' THEN '계정 잠김'
+            WHEN 'LOCKED_MANUALLY' THEN '계정 수동 잠김'
+            WHEN 'UNLOCK' THEN '잠김 해제'
+            WHEN 'EXPIRED' THEN '만료됨'
+            ELSE ual.action_type
+        END AS event_name,
+        ual.action_type AS raw_event_type,
+
+        ual.user_login_id AS target_login_id,
+        ual.user_name AS target_user_name,
+        ual.user_email AS target_user_email,
+        target_user.status AS current_user_status,
+        target_user.created_at AS target_user_created_at,
+        target_user.last_login_at AS target_user_last_login_at,
+        target_user.unlocked_at AS target_user_unlocked_at,
+
+        actor.login_id AS actor_login_id,
+        COALESCE(actor.name, ual.actor_user_name) AS actor_name,
+
+        CASE
+            WHEN ual.action_type = 'LOCKED'
+                THEN COALESCE(ual.message, '로그인 실패 횟수 초과')
+            WHEN ual.action_type = 'LOCKED_MANUALLY'
+                THEN COALESCE(ual.message, '관리자 수동 잠금')
+            WHEN ual.action_type = 'UNLOCK'
+                THEN COALESCE(ual.message, '잠김 해제')
+            WHEN ual.action_type = 'EXPIRED'
+                THEN COALESCE(ual.message, '계정 만료')
+            ELSE ual.message
+        END AS reason,
+        ual.client_ip,
+        NULL AS detail
+    FROM querypie_log.l_user_auth_logs ual
+    LEFT JOIN querypie.users target_user
+      ON target_user.id = ual.user_id
+    LEFT JOIN querypie.users actor
+      ON actor.id = ual.actor_user_id
+    WHERE ual.action_type IN (
+        'LOCKED',
+        'LOCKED_MANUALLY',
+        'UNLOCK',
+        'EXPIRED'
+    )
+)
+SELECT
+    DATE_FORMAT(CONVERT_TZ(event_time, '+00:00', '+09:00'), '%Y-%m-%d %H:%i:%s') AS `시간`,
+    event_name AS `이벤트`,
+    COALESCE(target_login_id, target_user_name) AS `사용자 Id or Name`,
+    actor_login_id AS `행위자 Id`,
+    IFNULL(reason, '') AS `사유`,
+    DATE_FORMAT(CONVERT_TZ(target_user_created_at, '+00:00', '+09:00'), '%Y-%m-%d %H:%i:%s') AS '사용자생성일',
+    DATE_FORMAT(CONVERT_TZ(target_user_last_login_at, '+00:00', '+09:00'), '%Y-%m-%d %H:%i:%s') AS '마지막로그인',
+    DATE_FORMAT(CONVERT_TZ(target_user_unlocked_at, '+00:00', '+09:00'), '%Y-%m-%d %H:%i:%s') AS 'Unlock시간'
+FROM (
+    SELECT * FROM user_activity_logs
+    UNION ALL
+    SELECT * FROM user_auth_logs
+) logs
+ORDER BY event_time ASC;

--- a/querypie-report/user_history/user_login_failure.sql
+++ b/querypie-report/user_history/user_login_failure.sql
@@ -1,0 +1,11 @@
+SET @start_kst = '2025-01-01 00:00:00';
+SET @end_kst = '2025-02-01 00:00:00';
+
+SELECT
+    DATE_ADD(acted_at, INTERVAL 9 HOUR) AS acted_at_kst,
+    user_login_id, user_name, user_email, client_ip, host_name, message
+FROM querypie_log.l_user_auth_logs FORCE INDEX (idx_createdat)
+WHERE created_at >= DATE_SUB(@start_kst, INTERVAL 9 HOUR)
+  AND created_at < DATE_SUB(@end_kst, INTERVAL 9 HOUR)
+  AND action_type = 'LOGIN'
+  AND error = 1;

--- a/querypie-report/user_history/user_login_success.sql
+++ b/querypie-report/user_history/user_login_success.sql
@@ -1,0 +1,26 @@
+SET @start_kst = '2025-01-01 00:00:00';
+SET @end_kst = '2025-02-01 00:00:00';
+
+SELECT
+    id,
+    hash,
+    user_id,
+    user_login_id,
+    user_name,
+    user_email,
+    action_type,
+    DATE_ADD(acted_at, INTERVAL 9 HOUR) AS acted_at_kst,
+    error,
+    message,
+    client_ip,
+    host_name,
+    actor_user_id,
+    actor_user_name,
+    created_by,
+    DATE_ADD(created_at, INTERVAL 9 HOUR) AS created_at_kst
+FROM querypie_log.l_user_auth_logs
+WHERE action_type = 'LOGIN'
+  AND error = 0
+  AND acted_at >= DATE_SUB(@start_kst, INTERVAL 9 HOUR)
+  AND acted_at < DATE_SUB(@end_kst, INTERVAL 9 HOUR)
+ORDER BY acted_at;

--- a/querypie-report/workflow_sql_audit_export/README.md
+++ b/querypie-report/workflow_sql_audit_export/README.md
@@ -1,0 +1,164 @@
+# Workflow SQL Audit Export
+
+승인·실행이 완료된 SQL Workflow 요청을 CSV로 추출하고, Query Audit·Ledger 정책 정보를 결합해 감사용 CSV를 생성하는 Python 2.7 호환 도구입니다.
+
+## 구성
+
+- `export_workflow_sql_requests.py`: Workflow 요청, 결제선, 승인자 및 승인 일시를 원본 CSV로 추출합니다.
+- `enrich_workflow_sql_audit.py`: Query Audit의 실행 쿼리·대상 테이블과 Ledger 정책 테이블 매칭 결과를 최종 CSV에 추가합니다.
+- `export_workflow_sql_audit.sh`: 위 두 단계를 순서대로 실행합니다.
+
+## 사전 조건
+
+- Python 2.7.7 이상 (권장: Python 2.7.18)
+- MySQL 접근 권한
+  - App DB: Workflow, 결제선, Ledger 정책 조회
+  - Log DB: Query Audit 조회
+  - Snapshot DB: 변경 전·후 데이터 옵션 사용 시에만 필요
+- `PyMySQL` 또는 `mysql-connector-python`
+  - 네트워크가 제한된 환경에서는 `vendor-python2` 디렉터리에 사전 다운로드한 패키지를 두고 실행합니다.
+
+### Python DB 드라이버 설치
+
+권장 방식은 Python 2.7용 PyMySQL을 프로젝트의 `vendor-python2`에 설치하는 것입니다.
+
+```bash
+cd workflow_sql_audit_export
+python2.7 -m pip install --target vendor-python2 'PyMySQL<1.0'
+```
+
+이 명령을 실행하면 셸 스크립트가 `vendor-python2`를 자동으로 사용합니다. 이 방식을 사용하지 않는다면, 실행 환경의 Python 2.7에 PyMySQL 또는 `mysql-connector-python`을 설치해야 합니다.
+
+환경에 따라 DB 연결 과정에서 `cryptography` 관련 오류가 발생할 수 있습니다. 이 경우 Python 2.7과 호환되는 `cryptography` 패키지를 설치하거나, QueryPie Agent를 통해 DB에 연결하면 문제 없이 처리할 수 있습니다.
+
+## 실행
+
+실행 스크립트가 있는 디렉터리에서 실행합니다.
+
+```bash
+cd workflow_sql_audit_export
+
+export QUERYPIE_DB_PASSWORD='앱 DB 비밀번호'
+./export_workflow_sql_audit.sh
+```
+
+기본 추출 기간은 셸 스크립트의 `FROM`, `TO` 값입니다. 기간·결제선·출력 경로를 바꾸려면 [export_workflow_sql_audit.sh](export_workflow_sql_audit.sh)의 상단 변수를 수정합니다.
+
+### 연결 환경변수
+
+App DB 설정은 필수 비밀번호 외에는 기본값을 사용합니다.
+
+```bash
+export QUERYPIE_DB_HOST='127.0.0.1'
+export QUERYPIE_DB_PORT='3306'
+export QUERYPIE_DB_USER='querypie'
+export QUERYPIE_DB_PASSWORD='...'
+export QUERYPIE_DB_NAME='querypie'
+```
+
+Log DB와 Snapshot DB가 분리되어 있으면 아래 값을 추가로 설정합니다. 설정하지 않으면 Log DB는 App DB 설정을, Snapshot DB는 Log DB 설정을 상속합니다.
+
+```bash
+export QUERYPIE_LOG_DB_HOST='...'
+export QUERYPIE_LOG_DB_PORT='3306'
+export QUERYPIE_LOG_DB_USER='...'
+export QUERYPIE_LOG_DB_PASSWORD='...'
+export QUERYPIE_LOG_DB_NAME='querypie_log'
+
+export QUERYPIE_SNAPSHOT_DB_HOST='...'
+export QUERYPIE_SNAPSHOT_DB_PORT='3306'
+export QUERYPIE_SNAPSHOT_DB_USER='...'
+export QUERYPIE_SNAPSHOT_DB_PASSWORD='...'
+export QUERYPIE_SNAPSHOT_DB_NAME='querypie_snapshot'
+```
+
+비밀번호는 스크립트나 명령행에 기록하지 말고 환경변수로만 제공합니다.
+
+### 결제선 필터
+
+기본값은 모든 결제선을 추출합니다. 특정 결제선만 추출하려면 `export_workflow_sql_audit.sh`의 `APPROVAL_RULE_NAMES`에 쉼표로 구분한 이름을 넣습니다.
+
+```bash
+APPROVAL_RULE_NAMES="운영 결제선,보안 결제선"
+```
+
+직접 Python 스크립트를 실행할 때는 아래처럼 지정할 수 있습니다.
+
+```bash
+python2.7 export_workflow_sql_requests.py \
+  --output workflows/workflow.csv \
+  --from-kst '2026-07-01 00:00:00' \
+  --to-kst '2026-08-01 00:00:00' \
+  --approval-rule-name '운영 결제선,보안 결제선'
+```
+
+### 변경 전·후 데이터 옵션
+
+기본 실행은 변경 전·후 DML Snapshot 데이터를 조회하지 않으며 Snapshot DB에도 연결하지 않습니다. 필요한 경우에만 다음 값을 설정합니다.
+
+```bash
+INCLUDE_DML_SNAPSHOTS=true ./export_workflow_sql_audit.sh
+```
+
+옵션을 켜면 최종 CSV에 `변경전데이터`, `변경후데이터` 컬럼이 추가됩니다. 대용량 데이터는 `--inline-threshold-bytes`와 `--large-file-mode` 설정의 영향을 받습니다.
+
+## 생성 파일
+
+기본 실행은 다음 경로에 파일을 생성합니다.
+
+```text
+workflows/
+  workflow.001.csv                # Workflow 원본 추출 결과
+  result/
+    output_workflow.001.csv       # Query Audit·Ledger 매칭이 추가된 최종 결과
+  progress/                       # 파일별 처리 로그
+```
+
+`--rows-per-file` 기본값에 따라 원본 CSV가 여러 파일로 나뉠 수 있습니다.
+
+## 최종 CSV 데이터
+
+기본 출력 컬럼은 아래 순서입니다. `INCLUDE_DML_SNAPSHOTS=true`일 때만 `변경전데이터`, `변경후데이터`가 `요청자` 뒤에 추가됩니다.
+
+| 순서 | 컬럼 | 설명 |
+| ---: | --- | --- |
+| 1 | `workflow 상신일` | Workflow 요청 시간(KST) |
+| 2 | `사후결제여부` | Workflow의 `urgent` 플래그를 `Y`/`N`으로 표시 |
+| 3 | `변경수행일` | SQL 실행 완료 시각(KST) |
+| 4 | `요청자` | Workflow 요청자 |
+| 조건부 | `변경전데이터` | DML Snapshot 변경 전 데이터. Snapshot 옵션 사용 시에만 추가 |
+| 조건부 | `변경후데이터` | DML Snapshot 변경 후 데이터. Snapshot 옵션 사용 시에만 추가 |
+| 5 | `변경제목` | Workflow 요청 제목 |
+| 6 | `변경사유` | Workflow 요청 사유 또는 설명 |
+| 7 | `Connection/DB명` | SQL 실행 대상 Connection과 Database |
+| 8 | `테이블명` | Query Audit이 기록한 대상 테이블 |
+| 9 | `Ledger 테이블 여부` | 대상 테이블의 활성 Ledger 정책 테이블 매칭 여부 |
+| 10 | `매칭 Ledger 테이블` | 매칭된 Ledger 정책의 Database/Schema/Table |
+| 11 | `Ledger 테이블 등록일` | 매칭된 Ledger 정책 테이블의 등록 시각(KST) |
+| 12 | `Ledger 테이블 수정일` | 매칭된 Ledger 정책 테이블의 마지막 수정 시각(KST) |
+| 13 | `컬럼명` | Snapshot 비교로 식별한 변경 컬럼 |
+| 14 | `대상건수` | Query Audit의 처리 건수 또는 Snapshot에서 계산한 건수 |
+| 15 | `쿼리실행시간` | Query Audit의 SQL 실행 시각(KST) |
+| 16 | `수행쿼리` | Query Audit의 원본 SQL |
+| 17 | `수행자` | SQL 실행 담당자 |
+| 18 | `1차승인자` | 1차 결제 승인자 |
+| 19 | `1차승인일시` | 1차 결제 처리 시각(KST) |
+| 20 | `2차승인자` | 2차 결제 승인자 |
+| 21 | `2차승인일시` | 2차 결제 처리 시각(KST) |
+| 22 | `3차승인자` | 3차 결제 승인자 |
+| 23 | `3차승인일시` | 3차 결제 처리 시각(KST) |
+| 24 | `4차승인자` | 4차 결제 승인자 |
+| 25 | `4차승인일시` | 4차 결제 처리 시각(KST) |
+| 26 | `변경요청근거(관리툴링크)` | 요청 사유에서 찾은 URL 또는 Jira 이슈 키. Jira 키는 URL로 변환하지 않음 |
+| 27 | `Workflow Ledger 여부` | 개별 Workflow Request의 `ledger` 플래그 (`Y`/`N`) |
+| 28 | `결제선 Ledger 여부` | 적용된 Workflow Rule의 `ledger` 플래그 (`Y`/`N`) |
+| 29 | `Ledger` | 적용된 결제선 이름 |
+| 30 | `workflow_uuid` | Workflow Request UUID |
+| 31 | `workflow_id` | Workflow Request ID |
+
+## 유의 사항
+
+- 시간 조건 입력은 KST이며, DB의 UTC 시간과 비교할 때 스크립트가 변환합니다.
+- 조회 대상은 `SQL_EXECUTION`, 승인 상태 `APPROVED`, 실행 상태 `SUCCESS`인 Workflow 요청입니다.
+- Query Audit 대상 테이블이 여러 개면 Ledger 매칭 값은 `테이블명: 값` 형태로 함께 표시될 수 있습니다.
+- Snapshot 데이터에는 민감한 변경 전·후 값이 포함될 수 있으므로 필요한 경우에만 옵션을 켜고, 생성된 CSV의 접근 권한을 관리하세요.

--- a/querypie-report/workflow_sql_audit_export/enrich_workflow_sql_audit.py
+++ b/querypie-report/workflow_sql_audit_export/enrich_workflow_sql_audit.py
@@ -1,0 +1,1304 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Append Query Audit SQL text and DML snapshot data to a Workflow report CSV.
+
+Python 2.7 compatible on purpose: some customer/operation hosts still ship old
+Python. The script does not call QueryPie APIs. It reads Query Audit rows from
+querypie_log and reads DML snapshot blobs from the Engine snapshot database.
+"""
+from __future__ import print_function
+
+import argparse
+import csv
+import gzip
+import io
+import json
+import os
+import sys
+import traceback
+from collections import defaultdict
+
+
+PY2 = sys.version_info[0] == 2
+QUERY_SEPARATOR = u"\n\n--- query audit ---\n\n"
+SNAPSHOT_SEPARATOR = u"\n\n--- dml snapshot ---\n\n"
+TOO_LARGE_MESSAGE = u"파일 사이즈가 너무 커서 CSV에 직접 넣기 어렵습니다. (%s)"
+TOO_LARGE_CELL_MESSAGE = u"파일 사이즈가 너무 커서 CSV에 직접 넣기 어렵습니다. (%s)"
+LARGE_FILE_SAVED_MESSAGE = u"파일 사이즈가 너무 커서 별도 파일로 저장했습니다. (%s)"
+
+
+class DbConfig(object):
+    def __init__(self, host, port, user, password, database, charset="utf8mb4"):
+        self.host = host
+        self.port = int(port)
+        self.user = user
+        self.password = password
+        self.database = database
+        self.charset = charset
+
+
+class QueryAuditRow(object):
+    def __init__(
+        self,
+        workflow_uuid,
+        query_audit_uuid,
+        sub_query_index,
+        executed_at,
+        processed_record_count,
+        short_query_text,
+        compressed_full_query_text,
+        target_object_names_csv,
+        data_changes_json,
+    ):
+        self.workflow_uuid = workflow_uuid
+        self.query_audit_uuid = query_audit_uuid
+        self.sub_query_index = sub_query_index
+        self.executed_at = executed_at
+        self.processed_record_count = processed_record_count
+        self.short_query_text = short_query_text
+        self.compressed_full_query_text = compressed_full_query_text
+        self.target_object_names_csv = target_object_names_csv
+        self.data_changes_json = data_changes_json
+
+
+class SnapshotValue(object):
+    def __init__(self, uuid, byte_count=None, content=None, message=None, file_path=None, inline_threshold=None):
+        self.uuid = uuid
+        self.byte_count = byte_count
+        self.content = content
+        self.message = message
+        self.file_path = file_path
+        self.inline_threshold = inline_threshold
+
+    def render(self):
+        if self.content is not None:
+            return self.content
+        if self.file_path:
+            return LARGE_FILE_SAVED_MESSAGE % (
+                self.byte_count if self.byte_count is not None else "unknown",
+            )
+        if self.message:
+            return self.message
+        return u"MISSING uuid=%s" % self.uuid
+
+
+def is_text(value):
+    if PY2:
+        return isinstance(value, unicode)  # noqa: F821  pylint: disable=undefined-variable
+    return isinstance(value, str)
+
+
+def to_text(value, encoding="utf-8"):
+    if value is None:
+        return u""
+    if is_text(value):
+        return value
+    if isinstance(value, bytes):
+        return value.decode(encoding, "replace")
+    return unicode(value) if PY2 else str(value)  # noqa: F821  pylint: disable=undefined-variable
+
+
+def csv_cell_encoding(encoding):
+    # utf-8-sig writes a BOM on every encode() call in Python 2. CSV cells must
+    # be encoded as plain UTF-8, with the BOM written once at file start.
+    return "utf-8" if encoding.lower().replace("_", "-") == "utf-8-sig" else encoding
+
+
+def strip_bom(value):
+    return to_text(value).lstrip(u"\ufeff")
+
+
+def to_csv_cell(value, encoding):
+    text = to_text(value, encoding)
+    return text.encode(csv_cell_encoding(encoding)) if PY2 else text
+
+
+def env_or_default(name, default=None):
+    value = os.environ.get(name)
+    return value if value not in (None, "") else default
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Enrich a Workflow CSV with Query Audit original queries and DML snapshot before/after data.",
+    )
+    parser.add_argument("--input", required=True, help="Input Workflow CSV path.")
+    parser.add_argument("--output", required=True, help="Output enriched CSV path.")
+    parser.add_argument(
+        "--workflow-column",
+        required=True,
+        help="Workflow UUID column. Use a 1-based index such as 1, or a header name when --header is set.",
+    )
+    parser.add_argument("--header", dest="header", action="store_true", default=True, help="CSV has a header row. Default.")
+    parser.add_argument("--no-header", dest="header", action="store_false", help="CSV has no header row.")
+    parser.add_argument("--encoding", default="utf-8-sig", help="Input/output CSV encoding. Default: utf-8-sig.")
+
+    parser.add_argument("--log-db-host", default=env_or_default("QUERYPIE_LOG_DB_HOST", "127.0.0.1"))
+    parser.add_argument("--log-db-port", type=int, default=int(env_or_default("QUERYPIE_LOG_DB_PORT", "3306") or "3306"))
+    parser.add_argument("--log-db-user", default=env_or_default("QUERYPIE_LOG_DB_USER", "querypie"))
+    parser.add_argument("--log-db-password", default=env_or_default("QUERYPIE_LOG_DB_PASSWORD", "querypie"))
+    parser.add_argument("--log-db-name", default=env_or_default("QUERYPIE_LOG_DB_NAME", "querypie_log"))
+
+    parser.add_argument("--app-db-host", default=env_or_default("QUERYPIE_DB_HOST", env_or_default("QUERYPIE_LOG_DB_HOST", "127.0.0.1")))
+    parser.add_argument("--app-db-port", type=int, default=int(env_or_default("QUERYPIE_DB_PORT", env_or_default("QUERYPIE_LOG_DB_PORT", "3306")) or "3306"))
+    parser.add_argument("--app-db-user", default=env_or_default("QUERYPIE_DB_USER", env_or_default("QUERYPIE_LOG_DB_USER", "querypie")))
+    parser.add_argument("--app-db-password", default=env_or_default("QUERYPIE_DB_PASSWORD", env_or_default("QUERYPIE_LOG_DB_PASSWORD", "querypie")))
+    parser.add_argument("--app-db-name", default=env_or_default("QUERYPIE_DB_NAME", "querypie"))
+
+    parser.add_argument("--snapshot-db-host", default=env_or_default("QUERYPIE_SNAPSHOT_DB_HOST"))
+    parser.add_argument("--snapshot-db-port", type=int, default=None)
+    parser.add_argument("--snapshot-db-user", default=env_or_default("QUERYPIE_SNAPSHOT_DB_USER"))
+    parser.add_argument("--snapshot-db-password", default=env_or_default("QUERYPIE_SNAPSHOT_DB_PASSWORD"))
+    parser.add_argument("--snapshot-db-name", default=env_or_default("QUERYPIE_SNAPSHOT_DB_NAME", "querypie_snapshot"))
+
+    parser.add_argument(
+        "--inline-threshold-bytes",
+        type=int,
+        default=10000,
+        help="Max snapshot size to inline in the output CSV. Larger snapshots are written to files by default. Default: 10000.",
+    )
+    parser.add_argument(
+        "--large-file-mode",
+        choices=("skip", "file"),
+        default="file",
+        help="For snapshots larger than the threshold: 'file' downloads to --snapshot-output-dir, 'skip' writes a too-large message. Default: file.",
+    )
+    parser.add_argument(
+        "--snapshot-output-dir",
+        default=None,
+        help="Directory for large snapshot files when --large-file-mode=file. Default: <output>.snapshots.",
+    )
+    parser.add_argument("--batch-size", type=int, default=500, help="Workflow UUID batch size for Query Audit lookup. Default: 500.")
+    parser.add_argument(
+        "--include-workflow-uuid",
+        action="store_true",
+        help="Keep the workflow UUID column in the output CSV. By default it is used for lookup only and removed from output.",
+    )
+    parser.add_argument("--include-query-audit-index", action="store_true", help="Output the query_audit_index column.")
+    parser.add_argument("--include-query-audit-uuid", action="store_true", help="Output the query_audit_uuid column.")
+    parser.add_argument("--include-dml-snapshot-refs", action="store_true", help="Output the dml_snapshot_refs column.")
+    parser.add_argument(
+        "--include-dml-snapshots",
+        action="store_true",
+        help="Fetch and output DML snapshot before/after data. Disabled by default.",
+    )
+    parser.add_argument(
+        "--include-internal-columns",
+        action="store_true",
+        help="Shortcut for --include-workflow-uuid, --include-query-audit-index, --include-query-audit-uuid, and --include-dml-snapshot-refs.",
+    )
+    parser.add_argument(
+        "--vendor-dir",
+        default=env_or_default("QUERYPIE_AUDIT_VENDOR_DIR"),
+        help="Directory containing pre-downloaded Python packages, for closed-network hosts. Also configurable with QUERYPIE_AUDIT_VENDOR_DIR.",
+    )
+    args = parser.parse_args()
+    if args.batch_size <= 0:
+        raise SystemExit("--batch-size must be greater than 0.")
+    if args.inline_threshold_bytes <= 0:
+        raise SystemExit("--inline-threshold-bytes must be greater than 0.")
+    if args.large_file_mode == "file" and not args.snapshot_output_dir:
+        args.snapshot_output_dir = args.output + ".snapshots"
+    return args
+
+
+def add_vendor_dir(vendor_dir):
+    if not vendor_dir:
+        return
+    if not os.path.isdir(vendor_dir):
+        raise SystemExit("Vendor directory does not exist: %s" % vendor_dir)
+    abs_vendor_dir = os.path.abspath(vendor_dir)
+    if abs_vendor_dir not in sys.path:
+        sys.path.insert(0, abs_vendor_dir)
+
+
+def connect(config):
+    try:
+        import pymysql
+
+        return pymysql.connect(
+            host=config.host,
+            port=config.port,
+            user=config.user,
+            password=config.password,
+            database=config.database,
+            charset=config.charset,
+            cursorclass=pymysql.cursors.DictCursor,
+            autocommit=True,
+        )
+    except ImportError:
+        try:
+            import mysql.connector
+        except ImportError:
+            raise SystemExit("Install PyMySQL or mysql-connector-python to use this script.")
+
+        return mysql.connector.connect(
+            host=config.host,
+            port=config.port,
+            user=config.user,
+            password=config.password,
+            database=config.database,
+            charset=config.charset,
+        )
+
+
+def cursor_for(conn):
+    module = conn.__class__.__module__
+    if module.startswith("mysql.connector"):
+        return conn.cursor(dictionary=True)
+    return conn.cursor()
+
+
+def dict_rows(cursor):
+    rows = cursor.fetchall()
+    if not rows:
+        return []
+    first = rows[0]
+    if isinstance(first, dict):
+        return rows
+    columns = [desc[0] for desc in cursor.description]
+    return [dict(zip(columns, row)) for row in rows]
+
+
+def chunks(values, size):
+    start = 0
+    while start < len(values):
+        yield values[start : start + size]
+        start += size
+
+
+def placeholders(count):
+    return ",".join(["%s"] * count)
+
+
+def read_csv(path, has_header, encoding):
+    if PY2:
+        fp = open(path, "rb")
+        try:
+            reader = csv.reader(fp)
+            all_rows = [[strip_bom(to_text(cell, csv_cell_encoding(encoding))) for cell in row] for row in reader]
+        finally:
+            fp.close()
+    else:
+        with open(path, "r", newline="", encoding=encoding) as fp:
+            all_rows = [[strip_bom(cell) for cell in row] for row in csv.reader(fp)]
+    if has_header and all_rows:
+        return all_rows[0], all_rows[1:]
+    return None, all_rows
+
+
+def write_csv(path, header, rows, encoding):
+    parent = os.path.dirname(os.path.abspath(path))
+    if parent and not os.path.exists(parent):
+        os.makedirs(parent)
+
+    if PY2:
+        fp = open(path, "wb")
+        try:
+            if encoding.lower().replace("_", "-") == "utf-8-sig":
+                fp.write(u"\ufeff".encode("utf-8"))
+            writer = csv.writer(fp)
+            if header is not None:
+                writer.writerow([to_csv_cell(cell, encoding) for cell in header])
+            for row in rows:
+                writer.writerow([to_csv_cell(cell, encoding) for cell in row])
+        finally:
+            fp.close()
+    else:
+        with open(path, "w", newline="", encoding=encoding) as fp:
+            writer = csv.writer(fp)
+            if header is not None:
+                writer.writerow(header)
+            writer.writerows(rows)
+
+
+def open_csv_writer(path, encoding):
+    parent = os.path.dirname(os.path.abspath(path))
+    if parent and not os.path.exists(parent):
+        os.makedirs(parent)
+
+    if PY2:
+        fp = open(path, "wb")
+        if encoding.lower().replace("_", "-") == "utf-8-sig":
+            fp.write(u"\ufeff".encode("utf-8"))
+        return fp, csv.writer(fp)
+
+    fp = open(path, "w", newline="", encoding=encoding)
+    return fp, csv.writer(fp)
+
+
+def write_csv_row(writer, row, encoding):
+    writer.writerow([to_csv_cell(cell, encoding) for cell in row])
+
+
+def normalize_uuid(value):
+    return to_text(value).strip().strip('"').strip("'")
+
+
+def parse_connection_database(value):
+    text = to_text(value).strip()
+    if u" / " in text:
+        connection_name, database_name = text.rsplit(u" / ", 1)
+        return connection_name.strip(), database_name.strip()
+    return text, u""
+
+
+def normalize_identifier(value):
+    text = to_text(value).strip()
+    while len(text) >= 2 and (
+        (text[0] == "`" and text[-1] == "`")
+        or (text[0] == '"' and text[-1] == '"')
+        or (text[0] == "'" and text[-1] == "'")
+        or (text[0] == "[" and text[-1] == "]")
+    ):
+        text = text[1:-1].strip()
+    return text.lower()
+
+
+def normalize_ledger_key(connection_name, database_name, schema_name, table_name):
+    return (
+        normalize_identifier(connection_name),
+        normalize_identifier(database_name),
+        normalize_identifier(schema_name),
+        normalize_identifier(table_name),
+    )
+
+
+def parse_query_table(value, fallback_database_name):
+    original = to_text(value).strip()
+    parts = [normalize_identifier(part) for part in original.split(".") if to_text(part).strip()]
+    if len(parts) >= 3:
+        return original, parts[0], parts[-2], parts[-1]
+    if len(parts) == 2:
+        return original, parts[0], u"", parts[1]
+    if len(parts) == 1:
+        return original, normalize_identifier(fallback_database_name), u"", parts[0]
+    return original, u"", u"", u""
+
+
+def render_table_name(database_name, schema_name, table_name):
+    return u".".join([value for value in (to_text(database_name).strip(), to_text(schema_name).strip(), to_text(table_name).strip()) if value])
+
+
+def read_ledger_targets(conn):
+    sql = """
+        SELECT DISTINCT
+            cg.name AS connection_name,
+            lp.database_name AS database_name,
+            lpt.schema_name AS schema_name,
+            lpt.table_name AS table_name,
+            DATE_FORMAT(DATE_ADD(lpt.created_at, INTERVAL 9 HOUR), '%%Y-%%m-%%d %%H:%%i:%%s') AS ledger_table_created_at,
+            DATE_FORMAT(DATE_ADD(lpt.updated_at, INTERVAL 9 HOUR), '%%Y-%%m-%%d %%H:%%i:%%s') AS ledger_table_updated_at
+        FROM ledger_policy_tables lpt
+        INNER JOIN policies p ON p.uuid = lpt.policy_uuid
+        INNER JOIN ledger_policies lp ON lp.policy_uuid = p.uuid
+        INNER JOIN workflow_rules ledger_rule ON ledger_rule.uuid = lpt.workflow_rule_uuid
+        INNER JOIN cluster_groups cg ON cg.uuid = p.object_uuid
+        WHERE p.object_type = 'CLUSTER_GROUP'
+          AND p.type = 'LEDGER'
+          AND p.deleted = 0
+          AND lp.deleted = 0
+          AND lpt.deleted = 0
+          AND ledger_rule.deleted = 0
+          AND ledger_rule.name = 'Ledger Rule'
+          AND cg.deleted = 0
+          AND cg.name IS NOT NULL AND cg.name <> ''
+          AND lp.database_name IS NOT NULL AND lp.database_name <> ''
+          AND lpt.table_name IS NOT NULL AND lpt.table_name <> ''
+        ORDER BY cg.name, lp.database_name, lpt.schema_name, lpt.table_name
+    """
+    exact_keys = set()
+    by_connection_database_table = defaultdict(list)
+    display_by_key = {}
+    created_at_by_key = {}
+    updated_at_by_key = {}
+    cursor = cursor_for(conn)
+    try:
+        cursor.execute(sql)
+        for row in dict_rows(cursor):
+            key = normalize_ledger_key(row.get("connection_name"), row.get("database_name"), row.get("schema_name"), row.get("table_name"))
+            exact_keys.add(key)
+            by_connection_database_table[(key[0], key[1], key[3])].append(key)
+            display_by_key[key] = render_table_name(row.get("database_name"), row.get("schema_name"), row.get("table_name"))
+            created_at_by_key[key] = to_text(row.get("ledger_table_created_at"))
+            updated_at_by_key[key] = to_text(row.get("ledger_table_updated_at"))
+    finally:
+        cursor.close()
+    return exact_keys, by_connection_database_table, display_by_key, created_at_by_key, updated_at_by_key
+
+
+def find_ledger_match(connection_name, database_name, schema_name, table_name, ledger_data):
+    exact_keys, by_connection_database_table, display_by_key, created_at_by_key, updated_at_by_key = ledger_data
+    key = normalize_ledger_key(connection_name, database_name, schema_name, table_name)
+    candidates = [key] if key in exact_keys else by_connection_database_table.get((key[0], key[1], key[3]), [])
+    if not candidates:
+        return False, u"", u"", u""
+    if key[2]:
+        candidates = [candidate for candidate in candidates if candidate[2] == key[2]]
+        if not candidates:
+            return False, u"", u"", u""
+    return (
+        True,
+        u", ".join([display_by_key.get(candidate, u"") for candidate in candidates]),
+        u", ".join([created_at_by_key.get(candidate, u"") for candidate in candidates]),
+        u", ".join([updated_at_by_key.get(candidate, u"") for candidate in candidates]),
+    )
+
+
+def resolve_workflow_column(rows, header, column):
+    if column.isdigit():
+        index = int(column) - 1
+    elif header is not None:
+        try:
+            index = header.index(column)
+        except ValueError:
+            raise SystemExit("Workflow column header not found: %s" % column)
+    else:
+        raise SystemExit("--workflow-column must be a 1-based index when --no-header is used.")
+
+    width = len(header) if header is not None else (len(rows[0]) if rows else 0)
+    if index < 0 or index >= width:
+        raise SystemExit("Workflow column index out of range: %s" % column)
+    return index
+
+
+def read_query_audits(conn, workflow_uuids, batch_size):
+    result = defaultdict(list)
+    sql_template = """
+        SELECT
+            l.query_request_uuid AS workflow_uuid,
+            l.uuid AS query_audit_uuid,
+            l.query_request_sub_query_index AS sub_query_index,
+            DATE_FORMAT(DATE_ADD(l.executed_at, INTERVAL 9 HOUR), '%%Y-%%m-%%d %%H:%%i:%%s') AS executed_at,
+            l.processed_record_count AS processed_record_count,
+            l.query_text AS short_query_text,
+            d.full_query_text AS compressed_full_query_text,
+            d.target_object_names AS target_object_names_csv,
+            d.data_changes AS data_changes_json
+        FROM l_query_execution_logs l
+        LEFT JOIN l_query_execution_log_details d ON d.id = l.id
+        WHERE l.query_request_uuid IN ({ids})
+          AND l.hidden = 0
+        ORDER BY l.query_request_uuid, l.query_request_sub_query_index, l.executed_at, l.id
+    """
+    cursor = cursor_for(conn)
+    try:
+        for batch in chunks(workflow_uuids, batch_size):
+            cursor.execute(sql_template.format(ids=placeholders(len(batch))), batch)
+            for row in dict_rows(cursor):
+                audit = QueryAuditRow(
+                    workflow_uuid=to_text(row.get("workflow_uuid")),
+                    query_audit_uuid=to_text(row.get("query_audit_uuid")),
+                    sub_query_index=row.get("sub_query_index"),
+                    executed_at=row.get("executed_at"),
+                    processed_record_count=row.get("processed_record_count"),
+                    short_query_text=to_text(row.get("short_query_text")) if row.get("short_query_text") is not None else None,
+                    compressed_full_query_text=row.get("compressed_full_query_text"),
+                    target_object_names_csv=to_text(row.get("target_object_names_csv")) if row.get("target_object_names_csv") is not None else None,
+                    data_changes_json=to_text(row.get("data_changes_json")) if row.get("data_changes_json") is not None else None,
+                )
+                result[audit.workflow_uuid].append(audit)
+    finally:
+        cursor.close()
+    return result
+
+
+def row_batches(rows, workflow_col_index, batch_size):
+    batch = []
+    workflow_uuids = set()
+    for row in rows:
+        batch.append(row)
+        workflow_uuid = normalize_uuid(row[workflow_col_index]) if len(row) > workflow_col_index else u""
+        if workflow_uuid:
+            workflow_uuids.add(workflow_uuid)
+        if len(workflow_uuids) >= batch_size:
+            yield batch
+            batch = []
+            workflow_uuids = set()
+    if batch:
+        yield batch
+
+
+def decode_query_text(compressed_full_query_text, short_query_text):
+    if compressed_full_query_text:
+        raw = bytes(compressed_full_query_text) if not PY2 else compressed_full_query_text
+        try:
+            return gzip.GzipFile(fileobj=io.BytesIO(raw)).read().decode("utf-8", "replace")
+        except Exception:
+            try:
+                return raw.decode("utf-8", "replace") if not PY2 else raw.decode("utf-8", "replace")
+            except Exception:
+                pass
+    return short_query_text or u""
+
+
+def parse_data_changes(value):
+    if not value:
+        return []
+    try:
+        parsed = json.loads(value)
+    except ValueError:
+        return []
+    if isinstance(parsed, list):
+        return [item for item in parsed if isinstance(item, dict)]
+    return []
+
+
+def parse_target_object_names(value):
+    names = []
+    for item in to_text(value).split(","):
+        append_unique(names, item)
+    return names
+
+
+def collect_snapshot_uuids(audits_by_workflow):
+    snapshot_uuids = set()
+    for audits in audits_by_workflow.values():
+        for audit in audits:
+            for change in parse_data_changes(audit.data_changes_json):
+                for key in ("oldDataSnapshotUuid", "newDataSnapshotUuid"):
+                    value = change.get(key)
+                    if is_text(value) and value.strip():
+                        snapshot_uuids.add(value.strip())
+    return snapshot_uuids
+
+
+def read_blob_meta(conn, snapshot_uuids, batch_size):
+    if not snapshot_uuids:
+        return {}
+    result = {}
+    names = sorted(snapshot_uuids)
+    sql_template = "SELECT name, bytes FROM blob_meta WHERE name IN ({ids})"
+    cursor = cursor_for(conn)
+    try:
+        for batch in chunks(names, batch_size):
+            cursor.execute(sql_template.format(ids=placeholders(len(batch))), batch)
+            for row in dict_rows(cursor):
+                result[to_text(row.get("name"))] = row.get("bytes")
+    finally:
+        cursor.close()
+    return result
+
+
+def read_blob_content(conn, name):
+    cursor = cursor_for(conn)
+    try:
+        cursor.execute("SELECT data FROM blobs WHERE name=%s ORDER BY idx", (name,))
+        parts = []
+        for row in dict_rows(cursor):
+            data = row.get("data")
+            if data is not None:
+                parts.append(bytes(data) if not PY2 else data)
+        if not parts:
+            return None
+        return b"".join(parts).decode("utf-8", "replace")
+    finally:
+        cursor.close()
+
+
+def materialize_snapshot(conn, name, blob_meta, threshold, large_file_mode, output_dir):
+    byte_count = blob_meta.get(name)
+    if name not in blob_meta:
+        return SnapshotValue(uuid=name, message=u"MISSING uuid=%s" % name)
+
+    if byte_count is not None and int(byte_count) >= threshold:
+        if large_file_mode == "file":
+            if output_dir is None:
+                raise SystemExit("--snapshot-output-dir is required when --large-file-mode=file")
+            content = read_blob_content(conn, name)
+            if content is None:
+                return SnapshotValue(uuid=name, byte_count=byte_count, message=u"MISSING uuid=%s bytes=%s" % (name, byte_count))
+            if not os.path.exists(output_dir):
+                os.makedirs(output_dir)
+            file_name = name.replace("/", "_")
+            if not file_name.lower().endswith(".csv"):
+                file_name += ".csv"
+            path = os.path.join(output_dir, file_name)
+            fp = io.open(path, "w", encoding="utf-8")
+            try:
+                fp.write(content)
+            finally:
+                fp.close()
+            return SnapshotValue(uuid=name, byte_count=byte_count, file_path=path, inline_threshold=threshold)
+
+        print("TOO_LARGE_MESSAGE: %s" % (byte_count), file=sys.stderr)
+        return SnapshotValue(
+            uuid=name,
+            byte_count=byte_count,
+            message=TOO_LARGE_MESSAGE % (byte_count),
+        )
+
+    content = read_blob_content(conn, name)
+    return SnapshotValue(uuid=name, byte_count=byte_count, content=content)
+
+
+def materialize_snapshot_cached(conn, name, blob_meta, threshold, large_file_mode, output_dir, cache):
+    if not name:
+        return None
+    if name not in cache:
+        cache[name] = materialize_snapshot(conn, name, blob_meta, threshold, large_file_mode, output_dir)
+    return cache[name]
+
+
+def byte_len(value):
+    return len(to_text(value).encode("utf-8"))
+
+
+def render_snapshot_values(values, threshold):
+    rendered_values = [value.render() for value in values if value is not None]
+    rendered = SNAPSHOT_SEPARATOR.join(rendered_values)
+    if rendered and byte_len(rendered) >= threshold:
+        return TOO_LARGE_CELL_MESSAGE % (byte_len(rendered))
+    return rendered
+
+
+def render_snapshot_side(snapshot_conn, snapshot_names, blob_meta, threshold, large_file_mode, output_dir):
+    rendered = []
+    for name in snapshot_names:
+        value = materialize_snapshot(snapshot_conn, name, blob_meta, threshold, large_file_mode, output_dir)
+        rendered.append(value.render())
+    return SNAPSHOT_SEPARATOR.join(rendered)
+
+
+def append_unique(values, value):
+    text = to_text(value).strip()
+    if text and text not in values:
+        values.append(text)
+
+
+def parse_snapshot_csv(content):
+    if content is None:
+        return [], []
+    if PY2:
+        fp = io.BytesIO(to_text(content).encode("utf-8"))
+        reader = csv.reader(fp)
+        rows = [[strip_bom(to_text(cell, "utf-8")) for cell in row] for row in reader]
+    else:
+        fp = io.StringIO(to_text(content))
+        rows = [[strip_bom(cell) for cell in row] for row in csv.reader(fp)]
+
+    rows = [row for row in rows if any(to_text(cell).strip() for cell in row)]
+    if not rows:
+        return [], []
+    return rows[0], rows[1:]
+
+
+def try_parse_json(value):
+    text = to_text(value).strip()
+    if not text:
+        return None
+    if not (text.startswith("{") or text.startswith("[")):
+        return None
+    try:
+        return json.loads(text)
+    except ValueError:
+        return None
+
+
+def flatten_json_paths(value, prefix=u""):
+    result = {}
+    if isinstance(value, dict):
+        for key in sorted(value.keys()):
+            path = u"%s.%s" % (prefix, to_text(key)) if prefix else to_text(key)
+            result.update(flatten_json_paths(value.get(key), path))
+        return result
+    if isinstance(value, list):
+        for index, item in enumerate(value):
+            path = u"%s[%s]" % (prefix, index) if prefix else u"[%s]" % index
+            result.update(flatten_json_paths(item, path))
+        if not value and prefix:
+            result[prefix] = u"[]"
+        return result
+    result[prefix or u"$"] = json.dumps(value, ensure_ascii=False, sort_keys=True)
+    return result
+
+
+def extract_json_documents_from_snapshot(snapshot_value):
+    if snapshot_value is None or snapshot_value.content is None:
+        return None
+
+    header, rows = parse_snapshot_csv(snapshot_value.content)
+    documents = []
+    for row in rows:
+        parsed = None
+        joined_row = u",".join([to_text(cell) for cell in row]).strip()
+        if len(row) > 1 and (joined_row.startswith("{") or joined_row.startswith("[")):
+            parsed = try_parse_json(joined_row)
+        if len(row) == 1:
+            parsed = try_parse_json(row[0])
+        if parsed is None:
+            for index, cell in enumerate(row):
+                column_name = header[index].lower() if index < len(header) else u""
+                if column_name in ("document", "documents", "value", "json", "data", "row") or try_parse_json(cell) is not None:
+                    parsed = try_parse_json(cell)
+                    if parsed is not None:
+                        break
+        if parsed is None:
+            return None
+        documents.append(parsed)
+    return documents
+
+
+def snapshot_row_count(snapshot_value):
+    if snapshot_value is None or snapshot_value.content is None:
+        return None
+    _, rows = parse_snapshot_csv(snapshot_value.content)
+    return len(rows)
+
+
+def snapshot_header_columns(snapshot_value):
+    if snapshot_value is None or snapshot_value.content is None:
+        return []
+    header, _ = parse_snapshot_csv(snapshot_value.content)
+    columns = []
+    for column in header:
+        append_unique(columns, column)
+    return columns
+
+
+def snapshot_non_empty_columns(snapshot_value, sample_size=3):
+    if snapshot_value is None or snapshot_value.content is None:
+        return []
+    header, rows = parse_snapshot_csv(snapshot_value.content)
+    columns = []
+    for row in rows[:sample_size]:
+        for index, cell in enumerate(row):
+            if not to_text(cell).strip():
+                continue
+            column_name = header[index] if index < len(header) and header[index] else u"column_%s" % (index + 1)
+            append_unique(columns, column_name)
+    return columns
+
+
+def is_document_like_columns(columns):
+    if not columns:
+        return False
+    normalized = [to_text(column).strip().lower() for column in columns]
+    if len(normalized) == 1 and normalized[0] in ("document", "documents", "value", "json", "data", "row"):
+        return True
+    return False
+
+
+def changed_json_paths_from_snapshots(before_value, after_value):
+    before_documents = extract_json_documents_from_snapshot(before_value)
+    after_documents = extract_json_documents_from_snapshot(after_value)
+    if before_documents is None or after_documents is None:
+        return []
+
+    max_rows = max(len(before_documents), len(after_documents))
+    changed = []
+    for row_index in range(max_rows):
+        before_flat = flatten_json_paths(before_documents[row_index]) if row_index < len(before_documents) else {}
+        after_flat = flatten_json_paths(after_documents[row_index]) if row_index < len(after_documents) else {}
+        for path in sorted(set(before_flat.keys()) | set(after_flat.keys())):
+            if before_flat.get(path) != after_flat.get(path):
+                append_unique(changed, path)
+    return changed
+
+
+def changed_columns_from_snapshots(before_value, after_value):
+    if (
+        before_value is None
+        or after_value is None
+        or before_value.content is None
+        or after_value.content is None
+    ):
+        return []
+
+    before_header, before_rows = parse_snapshot_csv(before_value.content)
+    after_header, after_rows = parse_snapshot_csv(after_value.content)
+    header_columns = []
+    for column in before_header + after_header:
+        append_unique(header_columns, column)
+
+    if is_document_like_columns(header_columns):
+        return []
+
+    if not before_header and not after_header:
+        return []
+
+    max_columns = max(len(before_header), len(after_header))
+    max_rows = max(len(before_rows), len(after_rows))
+    changed = []
+    for column_index in range(max_columns):
+        column_name = (
+            before_header[column_index]
+            if column_index < len(before_header) and before_header[column_index]
+            else (after_header[column_index] if column_index < len(after_header) else u"column_%s" % (column_index + 1))
+        )
+        different = False
+        for row_index in range(max_rows):
+            before_cell = (
+                before_rows[row_index][column_index]
+                if row_index < len(before_rows) and column_index < len(before_rows[row_index])
+                else u""
+            )
+            after_cell = (
+                after_rows[row_index][column_index]
+                if row_index < len(after_rows) and column_index < len(after_rows[row_index])
+                else u""
+            )
+            if before_cell != after_cell:
+                different = True
+                break
+        if different:
+            append_unique(changed, column_name)
+    return changed
+
+
+def format_scoped_values(items):
+    cleaned = [(to_text(scope).strip(), to_text(value).strip()) for scope, value in items if to_text(value).strip()]
+    if not cleaned:
+        return u""
+    scopes = [scope for scope, _ in cleaned if scope]
+    if len(cleaned) == 1:
+        return cleaned[0][1]
+    if scopes and len(set(scopes)) == len(cleaned):
+        return u", ".join([u"%s: %s" % (scope, value) for scope, value in cleaned])
+    values = []
+    for _, value in cleaned:
+        append_unique(values, value)
+    return u", ".join(values)
+
+
+def build_blank_enrichment():
+    return [u""] * len(ENRICHMENT_KEYS)
+
+
+def build_error_enrichment(audit, audit_index, message):
+    try:
+        query_text = decode_query_text(audit.compressed_full_query_text, audit.short_query_text)
+    except Exception:
+        query_text = audit.short_query_text or u""
+    return [
+        to_text(audit_index),
+        to_text(audit.sub_query_index) if audit.sub_query_index is not None else u"",
+        audit.query_audit_uuid,
+        to_text(audit.executed_at),
+        query_text,
+        to_text(audit.target_object_names_csv) if audit.target_object_names_csv is not None else u"",
+        u"",
+        to_text(audit.processed_record_count) if audit.processed_record_count is not None else u"",
+        message,
+        message,
+        u"",
+        u"",
+        u"",
+        u"",
+        u"",
+    ]
+
+
+def log_audit_processing_error(workflow_uuid, audit, audit_index):
+    print(
+        "ERROR while enriching DML snapshot: workflow_uuid=%s query_audit_uuid=%s query_index=%s sub_query_index=%s"
+        % (
+            workflow_uuid,
+            audit.query_audit_uuid,
+            audit_index,
+            audit.sub_query_index if audit.sub_query_index is not None else "",
+        ),
+        file=sys.stderr,
+    )
+    traceback.print_exc(file=sys.stderr)
+
+
+def build_enrichment_for_audit(
+    audit,
+    audit_index,
+    snapshot_conn,
+    blob_meta,
+    threshold,
+    large_file_mode,
+    output_dir,
+    connection_database,
+    ledger_data,
+    include_dml_snapshots,
+):
+    query_text = decode_query_text(audit.compressed_full_query_text, audit.short_query_text)
+    before_values = []
+    after_values = []
+    target_objects = parse_target_object_names(audit.target_object_names_csv)
+    scoped_columns = []
+    scoped_row_counts = []
+    change_summaries = []
+    ledger_matches = []
+    matched_ledger_tables = []
+    ledger_table_created_ats = []
+    ledger_table_updated_ats = []
+    snapshot_cache = {}
+    connection_name, fallback_database_name = parse_connection_database(connection_database)
+    for change in parse_data_changes(audit.data_changes_json):
+        old_uuid = change.get("oldDataSnapshotUuid")
+        new_uuid = change.get("newDataSnapshotUuid")
+        target_object = to_text(change.get("targetObject")).strip()
+        if not target_objects:
+            append_unique(target_objects, target_object)
+        before_value = None
+        after_value = None
+        if include_dml_snapshots and is_text(old_uuid) and old_uuid.strip():
+            before_value = materialize_snapshot_cached(
+                snapshot_conn,
+                old_uuid.strip(),
+                blob_meta,
+                threshold,
+                large_file_mode,
+                output_dir,
+                snapshot_cache,
+            )
+            before_values.append(before_value)
+        if include_dml_snapshots and is_text(new_uuid) and new_uuid.strip():
+            after_value = materialize_snapshot_cached(
+                snapshot_conn,
+                new_uuid.strip(),
+                blob_meta,
+                threshold,
+                large_file_mode,
+                output_dir,
+                snapshot_cache,
+            )
+            after_values.append(after_value)
+
+        changed_columns = []
+        if include_dml_snapshots and before_value is not None and after_value is not None:
+            for column in snapshot_non_empty_columns(before_value) + snapshot_non_empty_columns(after_value):
+                append_unique(changed_columns, column)
+            if is_document_like_columns(changed_columns):
+                changed_columns = []
+            elif not changed_columns:
+                fallback_columns = []
+                for column in snapshot_header_columns(before_value) + snapshot_header_columns(after_value):
+                    append_unique(fallback_columns, column)
+                if is_document_like_columns(fallback_columns):
+                    changed_columns = []
+                else:
+                    changed_columns = changed_columns_from_snapshots(before_value, after_value)
+        if changed_columns:
+            scoped_columns.append((target_object, u", ".join(changed_columns)))
+
+        if include_dml_snapshots and audit.processed_record_count is None:
+            before_count = snapshot_row_count(before_value)
+            after_count = snapshot_row_count(after_value)
+            row_counts = [count for count in (before_count, after_count) if count is not None]
+            if row_counts:
+                scoped_row_counts.append((target_object, to_text(max(row_counts))))
+
+        change_summaries.append(
+            json.dumps(
+                {
+                    "queryAuditUuid": audit.query_audit_uuid,
+                    "type": change.get("type"),
+                    "targetObject": change.get("targetObject"),
+                    "oldDataSnapshotUuid": old_uuid,
+                    "newDataSnapshotUuid": new_uuid,
+                },
+                ensure_ascii=False,
+            ),
+        )
+
+    before = render_snapshot_values(before_values, threshold)
+    after = render_snapshot_values(after_values, threshold)
+    for target_object in target_objects:
+        _, database_name, schema_name, table_name = parse_query_table(target_object, fallback_database_name)
+        is_ledger, matched_table, created_at, updated_at = find_ledger_match(
+            connection_name,
+            database_name,
+            schema_name,
+            table_name,
+            ledger_data,
+        )
+        ledger_matches.append((target_object, u"Y" if is_ledger else u"N"))
+        if is_ledger:
+            matched_ledger_tables.append((target_object, matched_table))
+            ledger_table_created_ats.append((target_object, created_at))
+            ledger_table_updated_ats.append((target_object, updated_at))
+    return [
+        to_text(audit_index),
+        to_text(audit.sub_query_index) if audit.sub_query_index is not None else u"",
+        audit.query_audit_uuid,
+        to_text(audit.executed_at),
+        query_text,
+        u", ".join(target_objects),
+        format_scoped_values(scoped_columns),
+        to_text(audit.processed_record_count) if audit.processed_record_count is not None else format_scoped_values(scoped_row_counts),
+        before,
+        after,
+        SNAPSHOT_SEPARATOR.join([to_text(item) for item in change_summaries]),
+        format_scoped_values(ledger_matches),
+        format_scoped_values(matched_ledger_tables),
+        format_scoped_values(ledger_table_created_ats),
+        format_scoped_values(ledger_table_updated_ats),
+    ]
+
+
+ENRICHMENT_KEYS = [
+    "query_audit_index",
+    "query_request_sub_query_index",
+    "query_audit_uuid",
+    "executed_at",
+    "query_original",
+    "target_object",
+    "changed_columns",
+    "affected_row_count",
+    "dml_snapshot_before",
+    "dml_snapshot_after",
+    "dml_snapshot_refs",
+    "is_ledger_table",
+    "matched_ledger_table",
+    "ledger_table_created_at",
+    "ledger_table_updated_at",
+]
+
+
+FINAL_COLUMN_SPECS = [
+    (u"workflow 상신일", "base", [u"workflow 상신일", u"상신일", u"requested_at"]),
+    (u"사후결제여부", "base", [u"사후결제여부", u"urgent"]),
+    (u"변경수행일", "base", [u"변경수행일", u"요청 시간", u"requested_at"]),
+    (u"요청자", "base", [u"요청자", u"변경요청자"]),
+    (u"변경제목", "base", [u"변경제목", u"변경 제목"]),
+    (u"변경사유", "base", [u"변경사유", u"사유"]),
+    (u"Connection/DB명", "base", [u"Connection/DB명", u"DB명 (Connection/DB)", u"DB명", u"Connection / Database"]),
+    (u"테이블명", "extra", "target_object"),
+    (u"Ledger 테이블 여부", "extra", "is_ledger_table"),
+    (u"매칭 Ledger 테이블", "extra", "matched_ledger_table"),
+    (u"Ledger 테이블 등록일", "extra", "ledger_table_created_at"),
+    (u"Ledger 테이블 수정일", "extra", "ledger_table_updated_at"),
+    (u"컬럼명", "extra", "changed_columns"),
+    (u"대상건수", "extra", "affected_row_count"),
+    (u"쿼리실행시간", "extra", "executed_at"),
+    (u"수행쿼리", "extra", "query_original"),
+    (u"수행자", "base", [u"수행자"]),
+    (u"1차승인자", "base", [u"1차승인자", u"책임자(1차 결제자)", u"책임자 (1차결제자)", u"책임자 (1차 결제자)", u"결재 라인 1"]),
+    (u"1차승인일시", "base", [u"1차승인일시", u"결재 라인 1 승인일시"]),
+    (u"2차승인자", "base", [u"2차승인자", u"제3자확인 (2차결제자)", u"제3자확인 (2차 결제자)", u"결재 라인 2"]),
+    (u"2차승인일시", "base", [u"2차승인일시", u"결재 라인 2 승인일시"]),
+    (u"3차승인자", "base", [u"3차승인자", u"결재 라인 3"]),
+    (u"3차승인일시", "base", [u"3차승인일시", u"결재 라인 3 승인일시"]),
+    (u"4차승인자", "base", [u"4차승인자", u"결재 라인 4"]),
+    (u"4차승인일시", "base", [u"4차승인일시", u"결재 라인 4 승인일시"]),
+    (u"변경요청근거(관리툴링크)", "base", [u"변경요청근거(관리툴링크)", u"변경요청 근거 (관리툴 링크)"]),
+    (u"Workflow Ledger 여부", "base", [u"Workflow Ledger 여부", u"workflow_ledger"]),
+    (u"결제선 Ledger 여부", "base", [u"결제선 Ledger 여부", u"approval_rule_ledger"]),
+    (u"Ledger", "base", [u"rule_name"]),
+    (u"workflow_uuid", "base", [u"workflow_uuid"]),
+    (u"workflow_id", "base", [u"workflow_id", u"id"]),
+]
+
+
+def normalize_header_name(value):
+    return to_text(value).replace(u" ", u"").strip().lower()
+
+
+def build_header_index(header):
+    result = {}
+    if header is None:
+        return result
+    for index, name in enumerate(header):
+        normalized = normalize_header_name(name)
+        if normalized and normalized not in result:
+            result[normalized] = index
+    return result
+
+
+def get_base_value(row, header_index, aliases):
+    for alias in aliases:
+        index = header_index.get(normalize_header_name(alias))
+        if index is not None and index < len(row):
+            return row[index]
+    return u""
+
+
+def enrichment_to_dict(values):
+    result = {}
+    for index, key in enumerate(ENRICHMENT_KEYS):
+        result[key] = values[index] if index < len(values) else u""
+    return result
+
+
+def selected_internal_columns(args):
+    columns = []
+    if args.include_internal_columns or args.include_workflow_uuid:
+        columns.append(("workflow_uuid", u"workflow_uuid"))
+    if args.include_internal_columns or args.include_query_audit_index:
+        columns.append(("query_audit_index", u"query_audit_index"))
+    if args.include_internal_columns or args.include_query_audit_uuid:
+        columns.append(("query_audit_uuid", u"query_audit_uuid"))
+    if args.include_internal_columns or args.include_dml_snapshot_refs:
+        columns.append(("dml_snapshot_refs", u"dml_snapshot_refs"))
+    return columns
+
+
+def final_column_specs(include_dml_snapshots):
+    specs = list(FINAL_COLUMN_SPECS)
+    if include_dml_snapshots:
+        insert_at = 4
+        specs[insert_at:insert_at] = [
+            (u"변경전데이터", "extra", "dml_snapshot_before"),
+            (u"변경후데이터", "extra", "dml_snapshot_after"),
+        ]
+    return specs
+
+
+def build_final_row(row, header_index, enrichment_values, internal_columns, workflow_uuid, column_specs):
+    enrichment = enrichment_to_dict(enrichment_values)
+    output = []
+    for _, source, selector in column_specs:
+        if source == "base":
+            output.append(get_base_value(row, header_index, selector))
+        else:
+            output.append(enrichment.get(selector, u""))
+
+    for key, _ in internal_columns:
+        if key == "workflow_uuid":
+            output.append(workflow_uuid)
+        else:
+            output.append(enrichment.get(key, u""))
+    return output
+
+
+def final_output_header(internal_columns, column_specs):
+    headers = [header for header, _, _ in column_specs]
+    headers.extend([header for _, header in internal_columns])
+    return headers
+
+
+def main():
+    args = parse_args()
+    add_vendor_dir(args.vendor_dir)
+
+    header, rows = read_csv(args.input, args.header, args.encoding)
+    if header is None:
+        raise SystemExit("--header is required for final audit column mapping.")
+    workflow_col_index = resolve_workflow_column(rows, header, args.workflow_column)
+    header_index = build_header_index(header)
+
+    workflow_uuids = sorted(
+        set(
+            normalize_uuid(row[workflow_col_index])
+            for row in rows
+            if len(row) > workflow_col_index and normalize_uuid(row[workflow_col_index])
+        ),
+    )
+
+    log_db = DbConfig(
+        host=args.log_db_host,
+        port=args.log_db_port,
+        user=args.log_db_user,
+        password=args.log_db_password,
+        database=args.log_db_name,
+    )
+    snapshot_db = DbConfig(
+        host=args.snapshot_db_host or args.log_db_host,
+        port=args.snapshot_db_port or args.log_db_port,
+        user=args.snapshot_db_user or args.log_db_user,
+        password=args.snapshot_db_password if args.snapshot_db_password is not None else args.log_db_password,
+        database=args.snapshot_db_name,
+    )
+    app_db = DbConfig(
+        host=args.app_db_host,
+        port=args.app_db_port,
+        user=args.app_db_user,
+        password=args.app_db_password,
+        database=args.app_db_name,
+    )
+
+    log_conn = connect(log_db)
+    snapshot_conn = connect(snapshot_db) if args.include_dml_snapshots else None
+    app_conn = connect(app_db)
+    output_fp = None
+    try:
+        ledger_data = read_ledger_targets(app_conn)
+        internal_columns = selected_internal_columns(args)
+        column_specs = final_column_specs(args.include_dml_snapshots)
+        output_header = final_output_header(internal_columns, column_specs)
+
+        output_fp, output_writer = open_csv_writer(args.output, args.encoding)
+        write_csv_row(output_writer, output_header, args.encoding)
+
+        found_audits = 0
+        snapshot_uuid_count = 0
+        output_row_count = 0
+        for row_batch in row_batches(rows, workflow_col_index, args.batch_size):
+            print("Gathering...", file=sys.stderr)
+            batch_workflow_uuids = sorted(
+                set(
+                    normalize_uuid(row[workflow_col_index])
+                    for row in row_batch
+                    if len(row) > workflow_col_index and normalize_uuid(row[workflow_col_index])
+                ),
+            )
+            if batch_workflow_uuids:
+                audits_by_workflow = read_query_audits(log_conn, batch_workflow_uuids, args.batch_size)
+            else:
+                audits_by_workflow = {}
+            snapshot_uuids = collect_snapshot_uuids(audits_by_workflow) if args.include_dml_snapshots else set()
+            blob_meta = read_blob_meta(snapshot_conn, snapshot_uuids, args.batch_size) if args.include_dml_snapshots else {}
+            found_audits += sum(len(value) for value in audits_by_workflow.values())
+            snapshot_uuid_count += len(snapshot_uuids)
+
+            for row in row_batch:
+                print("Processing...", file=sys.stderr)
+                workflow_uuid = normalize_uuid(row[workflow_col_index]) if len(row) > workflow_col_index else u""
+                audits = audits_by_workflow.get(workflow_uuid, [])
+                if not audits:
+                    write_csv_row(
+                        output_writer,
+                        build_final_row(row, header_index, build_blank_enrichment(), internal_columns, workflow_uuid, column_specs),
+                        args.encoding,
+                    )
+                    output_row_count += 1
+                    continue
+
+                for index, audit in enumerate(audits, 1):
+                    try:
+                        connection_database = get_base_value(
+                            row,
+                            header_index,
+                            [u"Connection/DB명", u"DB명 (Connection/DB)", u"DB명", u"Connection / Database"],
+                        )
+                        enrichment_values = build_enrichment_for_audit(
+                            audit,
+                            index,
+                            snapshot_conn,
+                            blob_meta,
+                            args.inline_threshold_bytes,
+                            args.large_file_mode,
+                            args.snapshot_output_dir,
+                            connection_database,
+                            ledger_data,
+                            args.include_dml_snapshots,
+                        )
+                    except Exception:
+                        log_audit_processing_error(workflow_uuid, audit, index)
+                        enrichment_values = build_error_enrichment(
+                            audit,
+                            index,
+                            u"DML snapshot 처리 중 오류가 발생했습니다. stderr 로그를 확인하세요.",
+                        )
+                    write_csv_row(
+                        output_writer,
+                        build_final_row(row, header_index, enrichment_values, internal_columns, workflow_uuid, column_specs),
+                        args.encoding,
+                    )
+                    output_row_count += 1
+
+        print("workflow rows: %s" % len(rows))
+        print("unique workflow uuids: %s" % len(workflow_uuids))
+        print("query audit rows: %s" % found_audits)
+        print("snapshot uuids processed: %s" % snapshot_uuid_count)
+        print("ledger table targets: %s" % len(ledger_data[0]))
+        print("output rows: %s" % output_row_count)
+        print("output: %s" % args.output)
+        return 0
+    finally:
+        if output_fp is not None:
+            output_fp.close()
+        log_conn.close()
+        if snapshot_conn is not None:
+            snapshot_conn.close()
+        app_conn.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/querypie-report/workflow_sql_audit_export/export_workflow_sql_audit.sh
+++ b/querypie-report/workflow_sql_audit_export/export_workflow_sql_audit.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+BASEDIR=workflows
+FROM="2025-07-01 00:00:00"
+TO="2026-07-01 00:00:00"
+# Leave empty to export every approval rule. Use commas for multiple names.
+APPROVAL_RULE_NAMES=""
+# Set to true to include DML snapshot before/after data in the output.
+INCLUDE_DML_SNAPSHOTS="${INCLUDE_DML_SNAPSHOTS:-false}"
+
+# App DB connection. QUERYPIE_LOG_DB_* and QUERYPIE_SNAPSHOT_DB_* may override
+# the corresponding values when those databases are hosted separately.
+DB_HOST="${QUERYPIE_DB_HOST:-127.0.0.1}"
+DB_PORT="${QUERYPIE_DB_PORT:-3306}"
+DB_USER="${QUERYPIE_DB_USER:-querypie}"
+DB_NAME="${QUERYPIE_DB_NAME:-querypie}"
+LOG_DB_HOST="${QUERYPIE_LOG_DB_HOST:-$DB_HOST}"
+LOG_DB_PORT="${QUERYPIE_LOG_DB_PORT:-$DB_PORT}"
+LOG_DB_USER="${QUERYPIE_LOG_DB_USER:-$DB_USER}"
+LOG_DB_NAME="${QUERYPIE_LOG_DB_NAME:-querypie_log}"
+SNAPSHOT_DB_HOST="${QUERYPIE_SNAPSHOT_DB_HOST:-$LOG_DB_HOST}"
+SNAPSHOT_DB_PORT="${QUERYPIE_SNAPSHOT_DB_PORT:-$LOG_DB_PORT}"
+SNAPSHOT_DB_USER="${QUERYPIE_SNAPSHOT_DB_USER:-$LOG_DB_USER}"
+SNAPSHOT_DB_NAME="${QUERYPIE_SNAPSHOT_DB_NAME:-querypie_snapshot}"
+VENDOR_DIR="${QUERYPIE_AUDIT_VENDOR_DIR:-./vendor-python2}"
+
+# Required. Set this before execution, for example:
+# export QUERYPIE_DB_PASSWORD='...'
+: "${QUERYPIE_DB_PASSWORD:?QUERYPIE_DB_PASSWORD must be set}"
+# Optional: use a distinct credential for querypie_log when needed.
+LOG_DB_PASSWORD="${QUERYPIE_LOG_DB_PASSWORD:-$QUERYPIE_DB_PASSWORD}"
+SNAPSHOT_DB_PASSWORD="${QUERYPIE_SNAPSHOT_DB_PASSWORD:-$LOG_DB_PASSWORD}"
+
+mkdir -p $BASEDIR/result
+mkdir -p $BASEDIR/progress
+
+echo " == Export =="
+
+APPROVAL_RULE_OPTION=()
+if [ -n "$APPROVAL_RULE_NAMES" ]; then
+  APPROVAL_RULE_OPTION=(--approval-rule-name "$APPROVAL_RULE_NAMES")
+fi
+
+DML_SNAPSHOT_OPTION=()
+if [ "$INCLUDE_DML_SNAPSHOTS" = "true" ]; then
+  DML_SNAPSHOT_OPTION=(--include-dml-snapshots)
+fi
+
+VENDOR_OPTION=()
+if [ -d "$VENDOR_DIR" ]; then
+  VENDOR_OPTION=(--vendor-dir "$VENDOR_DIR")
+fi
+
+python2.7 export_workflow_sql_requests.py \
+  --output $BASEDIR/workflow.csv \
+  --rows-per-file 70 \
+  --from-kst "$FROM" \
+  --to-kst "$TO" \
+  "${VENDOR_OPTION[@]}" \
+  --db-host "$DB_HOST" \
+  --db-port "$DB_PORT" \
+  --db-user "$DB_USER" \
+  --db-password "$QUERYPIE_DB_PASSWORD" \
+  --db-name "$DB_NAME" \
+  "${APPROVAL_RULE_OPTION[@]}" 2>&1 | tee $BASEDIR/progress_export
+
+for INPUT_PATH in $( /bin/ls $BASEDIR/workflow.*.csv ); do
+    INPUT_FILENAME=$( basename $INPUT_PATH)
+    echo " == Process $INPUT_FILENAME =="
+    python2.7 enrich_workflow_sql_audit.py \
+        "${VENDOR_OPTION[@]}" \
+        --input $BASEDIR/${INPUT_FILENAME} \
+        --output $BASEDIR/result/output_${INPUT_FILENAME} \
+        --workflow-column workflow_uuid \
+        --log-db-host "$LOG_DB_HOST" \
+        --log-db-port "$LOG_DB_PORT" \
+        --log-db-user "$LOG_DB_USER" \
+        --log-db-password "$LOG_DB_PASSWORD" \
+        --log-db-name "$LOG_DB_NAME" \
+        --app-db-host "$DB_HOST" \
+        --app-db-port "$DB_PORT" \
+        --app-db-user "$DB_USER" \
+        --app-db-password "$QUERYPIE_DB_PASSWORD" \
+        --app-db-name "$DB_NAME" \
+        --snapshot-db-host "$SNAPSHOT_DB_HOST" \
+        --snapshot-db-port "$SNAPSHOT_DB_PORT" \
+        --snapshot-db-user "$SNAPSHOT_DB_USER" \
+        --snapshot-db-password "$SNAPSHOT_DB_PASSWORD" \
+        --snapshot-db-name "$SNAPSHOT_DB_NAME" \
+        "${DML_SNAPSHOT_OPTION[@]}" \
+        --inline-threshold-bytes 2000 \
+        --large-file-mode skip 2>&1 | tee $BASEDIR/progress/progress_${INPUT_FILENAME}
+done

--- a/querypie-report/workflow_sql_audit_export/export_workflow_sql_requests.py
+++ b/querypie-report/workflow_sql_audit_export/export_workflow_sql_requests.py
@@ -1,0 +1,558 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Export SQL workflow requests to CSV, optionally filtered by approval rule names.
+
+Python 2.7 compatible. DB timestamps are stored in UTC; date filter arguments
+are accepted as KST and output timestamps are rendered as KST.
+"""
+from __future__ import print_function
+
+import argparse
+import csv
+import os
+import re
+import sys
+from datetime import datetime, timedelta
+
+
+PY2 = sys.version_info[0] == 2
+KST_OFFSET = timedelta(hours=9)
+DATETIME_FORMAT = "%Y-%m-%d %H:%M:%S"
+URL_PATTERN = re.compile(r"https?://[^\s,;\"'<>]+")
+ISSUE_KEY_PATTERN = re.compile(r"\b[A-Za-z]{3,}-\d+\b")
+
+
+class DbConfig(object):
+    def __init__(self, host, port, user, password, database, charset="utf8mb4"):
+        self.host = host
+        self.port = int(port)
+        self.user = user
+        self.password = password
+        self.database = database
+        self.charset = charset
+
+
+def is_text(value):
+    if PY2:
+        return isinstance(value, unicode)  # noqa: F821  pylint: disable=undefined-variable
+    return isinstance(value, str)
+
+
+def to_text(value, encoding="utf-8"):
+    if value is None:
+        return u""
+    if is_text(value):
+        return value
+    if isinstance(value, bytes):
+        return value.decode(encoding, "replace")
+    return unicode(value) if PY2 else str(value)  # noqa: F821  pylint: disable=undefined-variable
+
+
+def csv_cell_encoding(encoding):
+    return "utf-8" if encoding.lower().replace("_", "-") == "utf-8-sig" else encoding
+
+
+def to_csv_cell(value, encoding):
+    text = to_text(value)
+    return text.encode(csv_cell_encoding(encoding)) if PY2 else text
+
+
+def env_or_default(name, default=None):
+    value = os.environ.get(name)
+    return value if value not in (None, "") else default
+
+
+def split_approval_rule_names(values):
+    """Accept repeated --approval-rule-name arguments and comma-separated names."""
+    result = []
+    seen = set()
+    for value in values:
+        for item in to_text(value).split(","):
+            name = item.strip()
+            if name and name not in seen:
+                seen.add(name)
+                result.append(name)
+    return result
+
+
+def parse_kst_datetime(value, end_of_day=False):
+    text = value.strip()
+    if len(text) == 10:
+        text += " 23:59:59" if end_of_day else " 00:00:00"
+    try:
+        return datetime.strptime(text, DATETIME_FORMAT)
+    except ValueError:
+        raise SystemExit("Invalid datetime format: %s. Use YYYY-MM-DD or YYYY-MM-DD HH:MM:SS." % value)
+
+
+def format_datetime(value):
+    if value is None:
+        return u""
+    if isinstance(value, datetime):
+        return value.strftime(DATETIME_FORMAT)
+    return to_text(value)
+
+
+def add_vendor_dir(vendor_dir):
+    if not vendor_dir:
+        return
+    if not os.path.isdir(vendor_dir):
+        raise SystemExit("Vendor directory does not exist: %s" % vendor_dir)
+    abs_vendor_dir = os.path.abspath(vendor_dir)
+    if abs_vendor_dir not in sys.path:
+        sys.path.insert(0, abs_vendor_dir)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Export SQL workflow requests to CSV.")
+    parser.add_argument("--output", required=True, help="Output CSV path.")
+    parser.add_argument(
+        "--rows-per-file",
+        type=int,
+        default=200,
+        help="Maximum data rows per output CSV file. Use 0 to disable splitting. Default: 200.",
+    )
+    parser.add_argument(
+        "--from-kst",
+        default="2020-06-01 00:00:00",
+        help="Requested-at start time in KST. Inclusive. Default: 2020-06-01 00:00:00.",
+    )
+    parser.add_argument(
+        "--to-kst",
+        default="2026-08-01 00:00:00",
+        help="Requested-at end time in KST. Exclusive. Default: 2026-08-01 00:00:00.",
+    )
+    parser.add_argument("--encoding", default="utf-8-sig", help="Output CSV encoding. Default: utf-8-sig.")
+    parser.add_argument("--fetch-size", type=int, default=1000, help="Rows to fetch per DB round-trip. Default: 1000.")
+    parser.add_argument(
+        "--approval-rule-name",
+        action="append",
+        default=[],
+        help="Filter by approval rule name. Accepts comma-separated names and can be specified multiple times. Default: all approval rule names.",
+    )
+    parser.add_argument(
+        "--vendor-dir",
+        default=env_or_default("QUERYPIE_AUDIT_VENDOR_DIR"),
+        help="Directory containing pre-downloaded Python packages. Also configurable with QUERYPIE_AUDIT_VENDOR_DIR.",
+    )
+
+    parser.add_argument("--db-host", "--log-db-host", dest="db_host", default=env_or_default("QUERYPIE_DB_HOST", env_or_default("QUERYPIE_LOG_DB_HOST", "127.0.0.1")))
+    parser.add_argument("--db-port", "--log-db-port", dest="db_port", type=int, default=int(env_or_default("QUERYPIE_DB_PORT", env_or_default("QUERYPIE_LOG_DB_PORT", "3306")) or "3306"))
+    parser.add_argument("--db-user", "--log-db-user", dest="db_user", default=env_or_default("QUERYPIE_DB_USER", env_or_default("QUERYPIE_LOG_DB_USER", "querypie")))
+    parser.add_argument("--db-password", "--log-db-password", dest="db_password", default=env_or_default("QUERYPIE_DB_PASSWORD", env_or_default("QUERYPIE_LOG_DB_PASSWORD", "querypie")))
+    parser.add_argument("--db-name", "--log-db-name", dest="db_name", default=env_or_default("QUERYPIE_DB_NAME", env_or_default("QUERYPIE_LOG_DB_NAME", "querypie")))
+    args = parser.parse_args()
+    if args.rows_per_file < 0:
+        raise SystemExit("--rows-per-file must be 0 or greater.")
+    args.approval_rule_name = split_approval_rule_names(args.approval_rule_name)
+    return args
+
+
+def connect(config, streaming=False):
+    try:
+        import pymysql
+
+        cursor_class = pymysql.cursors.SSCursor if streaming else pymysql.cursors.Cursor
+        return pymysql.connect(
+            host=config.host,
+            port=config.port,
+            user=config.user,
+            password=config.password,
+            database=config.database,
+            charset=config.charset,
+            cursorclass=cursor_class,
+            autocommit=True,
+        )
+    except ImportError:
+        try:
+            import mysql.connector
+        except ImportError:
+            raise SystemExit("Install PyMySQL or mysql-connector-python to use this script.")
+
+        return mysql.connector.connect(
+            host=config.host,
+            port=config.port,
+            user=config.user,
+            password=config.password,
+            database=config.database,
+            charset=config.charset,
+        )
+
+
+def open_csv_writer(path, encoding):
+    parent = os.path.dirname(os.path.abspath(path))
+    if parent and not os.path.exists(parent):
+        os.makedirs(parent)
+
+    if PY2:
+        fp = open(path, "wb")
+        if encoding.lower().replace("_", "-") == "utf-8-sig":
+            fp.write(u"\ufeff".encode("utf-8"))
+        return fp, csv.writer(fp, quoting=csv.QUOTE_ALL)
+
+    fp = open(path, "w", newline="", encoding=encoding)
+    return fp, csv.writer(fp, quoting=csv.QUOTE_ALL)
+
+
+def write_row(writer, row, encoding):
+    writer.writerow([to_csv_cell(cell, encoding) for cell in row])
+
+
+def extract_unique_urls(value):
+    urls = []
+    seen = set()
+    for match in URL_PATTERN.findall(to_text(value)):
+        url = match.rstrip(u".)]}")
+        seen.add(url)
+    for match in ISSUE_KEY_PATTERN.findall(to_text(value)):
+        key = to_text(match).upper()
+        seen.add(key)
+    return u", ".join(list(seen))
+
+
+def transform_export_row(row):
+    values = list(row)
+    if len(values) >= 21:
+        values[20] = extract_unique_urls(values[8])
+    return values
+
+
+def split_output_path(output_path, file_index):
+    #if file_index <= 1:
+    #    return output_path
+    base, ext = os.path.splitext(output_path)
+    if not ext:
+        ext = ".csv"
+    return "%s.%03d%s" % (base, file_index, ext)
+
+
+def export_rows(conn, output_path, from_utc, to_utc, encoding, fetch_size, rows_per_file, approval_rule_names):
+    approval_rule_filter = ""
+    if approval_rule_names:
+        approval_rule_filter = "          AND rule.name IN (%s)\n" % ",".join(["%s"] * len(approval_rule_names))
+
+    sql = """
+        WITH approval_lines AS (
+            SELECT
+                a.workflow_request_uuid,
+
+                GROUP_CONCAT(
+                    CASE WHEN a.`order` = 0 AND a.status IN ('APPROVED', 'REJECTED') THEN
+                        CONCAT(
+                            CASE a.status
+                                WHEN 'REJECTED' THEN 'REJECT '
+                                ELSE ''
+                            END,
+                            COALESCE(
+                                NULLIF(a.actor_login_id, ''),
+                                NULLIF(actor.login_id, ''),
+                                NULLIF(a.action_by_uuid, ''),
+                                NULLIF(a.api_user_uuid, ''),
+                                'UNKNOWN'
+                            )
+                        )
+                    END
+                    ORDER BY a.action_at, COALESCE(a.actor_login_id, actor.login_id, a.action_by_uuid)
+                    SEPARATOR ', '
+                ) AS approval_step_1,
+
+                GROUP_CONCAT(
+                    CASE WHEN a.`order` = 0 AND a.status IN ('APPROVED', 'REJECTED') THEN
+                        DATE_FORMAT(DATE_ADD(a.action_at, INTERVAL 9 HOUR), '%%Y-%%m-%%d %%H:%%i:%%s')
+                    END
+                    ORDER BY a.action_at, COALESCE(a.actor_login_id, actor.login_id, a.action_by_uuid)
+                    SEPARATOR ', '
+                ) AS approval_step_1_at,
+
+                GROUP_CONCAT(
+                    CASE WHEN a.`order` = 1 AND a.status IN ('APPROVED', 'REJECTED') THEN
+                        CONCAT(
+                            CASE a.status
+                                WHEN 'REJECTED' THEN 'REJECT '
+                                ELSE ''
+                            END,
+                            COALESCE(
+                                NULLIF(a.actor_login_id, ''),
+                                NULLIF(actor.login_id, ''),
+                                NULLIF(a.action_by_uuid, ''),
+                                NULLIF(a.api_user_uuid, ''),
+                                'UNKNOWN'
+                            )
+                        )
+                    END
+                    ORDER BY a.action_at, COALESCE(a.actor_login_id, actor.login_id, a.action_by_uuid)
+                    SEPARATOR ', '
+                ) AS approval_step_2,
+
+                GROUP_CONCAT(
+                    CASE WHEN a.`order` = 1 AND a.status IN ('APPROVED', 'REJECTED') THEN
+                        DATE_FORMAT(DATE_ADD(a.action_at, INTERVAL 9 HOUR), '%%Y-%%m-%%d %%H:%%i:%%s')
+                    END
+                    ORDER BY a.action_at, COALESCE(a.actor_login_id, actor.login_id, a.action_by_uuid)
+                    SEPARATOR ', '
+                ) AS approval_step_2_at,
+
+                GROUP_CONCAT(
+                    CASE WHEN a.`order` = 2 AND a.status IN ('APPROVED', 'REJECTED') THEN
+                        CONCAT(
+                            CASE a.status
+                                WHEN 'REJECTED' THEN 'REJECT '
+                                ELSE ''
+                            END,
+                            COALESCE(
+                                NULLIF(a.actor_login_id, ''),
+                                NULLIF(actor.login_id, ''),
+                                NULLIF(a.action_by_uuid, ''),
+                                NULLIF(a.api_user_uuid, ''),
+                                'UNKNOWN'
+                            )
+                        )
+                    END
+                    ORDER BY a.action_at, COALESCE(a.actor_login_id, actor.login_id, a.action_by_uuid)
+                    SEPARATOR ', '
+                ) AS approval_step_3,
+
+                GROUP_CONCAT(
+                    CASE WHEN a.`order` = 2 AND a.status IN ('APPROVED', 'REJECTED') THEN
+                        DATE_FORMAT(DATE_ADD(a.action_at, INTERVAL 9 HOUR), '%%Y-%%m-%%d %%H:%%i:%%s')
+                    END
+                    ORDER BY a.action_at, COALESCE(a.actor_login_id, actor.login_id, a.action_by_uuid)
+                    SEPARATOR ', '
+                ) AS approval_step_3_at,
+
+                GROUP_CONCAT(
+                    CASE WHEN a.`order` = 3 AND a.status IN ('APPROVED', 'REJECTED') THEN
+                        CONCAT(
+                            CASE a.status
+                                WHEN 'REJECTED' THEN 'REJECT '
+                                ELSE ''
+                            END,
+                            COALESCE(
+                                NULLIF(a.actor_login_id, ''),
+                                NULLIF(actor.login_id, ''),
+                                NULLIF(a.action_by_uuid, ''),
+                                NULLIF(a.api_user_uuid, ''),
+                                'UNKNOWN'
+                            )
+                        )
+                    END
+                    ORDER BY a.action_at, COALESCE(a.actor_login_id, actor.login_id, a.action_by_uuid)
+                    SEPARATOR ', '
+                ) AS approval_step_4,
+
+                GROUP_CONCAT(
+                    CASE WHEN a.`order` = 3 AND a.status IN ('APPROVED', 'REJECTED') THEN
+                        DATE_FORMAT(DATE_ADD(a.action_at, INTERVAL 9 HOUR), '%%Y-%%m-%%d %%H:%%i:%%s')
+                    END
+                    ORDER BY a.action_at, COALESCE(a.actor_login_id, actor.login_id, a.action_by_uuid)
+                    SEPARATOR ', '
+                ) AS approval_step_4_at
+            FROM querypie.workflow_request_approval_assignees a
+            LEFT JOIN querypie.users actor
+                   ON actor.uuid = a.action_by_uuid
+            GROUP BY a.workflow_request_uuid
+        )
+        SELECT
+            wr.id AS workflow_id,
+            wr.approval_status,
+            wr.execution_status,
+            DATE_FORMAT(
+                DATE_ADD(wr.requested_at, INTERVAL 9 HOUR),
+                '%%Y-%%m-%%d %%H:%%i:%%s'
+            ) AS `workflow 상신일`,
+            CASE WHEN COALESCE(wr.urgent, 0) = 1 THEN 'Y' ELSE 'N' END AS `사후결제여부`,
+            DATE_FORMAT(
+                DATE_ADD(ex.executed_at, INTERVAL 9 HOUR),
+                '%%Y-%%m-%%d %%H:%%i:%%s'
+            ) AS `변경수행일`,
+            wr.requester_login_id AS `변경요청자`,
+            wr.title AS `변경제목`,
+            wr.comments AS `변경사유`,
+            CONCAT_WS(' / ', NULLIF(cg.name, ''), NULLIF(se.`database`, '')) AS `DB명 (Connection/DB)`,
+            wr.requester_login_id AS `요청자`,
+            ex.execution_assignees AS `수행자`,
+            al.approval_step_1 AS `1차승인자`,
+            al.approval_step_1_at AS `1차승인일시`,
+            al.approval_step_2 AS `2차승인자`,
+            al.approval_step_2_at AS `2차승인일시`,
+            al.approval_step_3 AS `3차승인자`,
+            al.approval_step_3_at AS `3차승인일시`,
+            al.approval_step_4 AS `4차승인자`,
+            al.approval_step_4_at AS `4차승인일시`,
+            '' AS `변경요청 근거 (관리툴 링크)`,
+            wr.uuid AS workflow_uuid,
+            CASE WHEN COALESCE(wr.ledger, 0) = 1 THEN 'Y' ELSE 'N' END AS `Workflow Ledger 여부`,
+            CASE WHEN COALESCE(rule.ledger, 0) = 1 THEN 'Y' ELSE 'N' END AS `결제선 Ledger 여부`,
+            CASE
+                WHEN rule.name = 'Ledger Rule' THEN 'Ledger'
+                WHEN rule.name = 'Privacy Rule' THEN 'Privacy'
+                ELSE rule.name
+            END AS rule_name
+        FROM querypie.workflow_requests wr
+        LEFT JOIN querypie.workflow_rules rule
+               ON rule.uuid = wr.rule_uuid
+        LEFT JOIN querypie.workflow_request_detail_sql_executions se
+               ON se.workflow_request_uuid = wr.uuid
+        LEFT JOIN querypie.clusters c
+               ON c.uuid = se.object_uuid
+        LEFT JOIN querypie.cluster_groups cg
+               ON cg.id = c.group_id
+        LEFT JOIN approval_lines al
+               ON al.workflow_request_uuid = wr.uuid
+        LEFT JOIN (
+            SELECT
+                e.workflow_request_uuid,
+                MIN(
+                    CASE
+                        WHEN e.status = 'EXECUTED' THEN e.action_at
+                    END
+                ) AS executed_at,
+                GROUP_CONCAT(
+                    COALESCE(
+                        NULLIF(e.actor_login_id, ''),
+                        NULLIF(actor.login_id, ''),
+                        NULLIF(e.user_login_id, ''),
+                        NULLIF(assignee.login_id, ''),
+                        NULLIF(e.action_by_uuid, ''),
+                        NULLIF(e.user_uuid, ''),
+                        NULLIF(e.api_user_uuid, ''),
+                        'UNKNOWN'
+                    )
+                    ORDER BY e.action_at, e.finished_at, COALESCE(e.actor_login_id, e.user_login_id, e.action_by_uuid, e.user_uuid)
+                    SEPARATOR ', '
+                ) AS execution_assignees
+            FROM querypie.workflow_request_execution_assignees e
+            LEFT JOIN querypie.users assignee
+                   ON assignee.uuid = e.user_uuid
+            LEFT JOIN querypie.users actor
+                   ON actor.uuid = e.action_by_uuid
+            WHERE e.status IN ('EXECUTED', 'CANCELED')
+            GROUP BY e.workflow_request_uuid
+        ) ex
+               ON ex.workflow_request_uuid = wr.uuid
+        WHERE wr.requested_at >= %s
+          AND wr.requested_at <  %s
+          AND wr.request_type = 'SQL_EXECUTION'
+          AND wr.approval_status = 'APPROVED'
+          AND wr.execution_status = 'SUCCESS'
+{approval_rule_filter}
+        ORDER BY wr.id ASC
+    """.format(approval_rule_filter=approval_rule_filter)
+    header = [
+        u"workflow_id",
+        u"승인 상태",
+        u"실행 상태",
+        u"workflow 상신일",
+        u"사후결제여부",
+        u"변경수행일",
+        u"변경요청자",
+        u"변경제목",
+        u"변경사유",
+        u"DB명 (Connection/DB)",
+        u"요청자",
+        u"수행자",
+        u"1차승인자",
+        u"1차승인일시",
+        u"2차승인자",
+        u"2차승인일시",
+        u"3차승인자",
+        u"3차승인일시",
+        u"4차승인자",
+        u"4차승인일시",
+        u"변경요청 근거 (관리툴 링크)",
+        u"workflow_uuid",
+        u"Workflow Ledger 여부",
+        u"결제선 Ledger 여부",
+        u"rule_name",
+    ]
+
+    cursor = conn.cursor()
+    fp = None
+    writer = None
+    count = 0
+    output_paths = []
+
+    def open_next_file():
+        path = split_output_path(output_path, len(output_paths) + 1)
+        next_fp, next_writer = open_csv_writer(path, encoding)
+        write_row(next_writer, header, encoding)
+        output_paths.append(path)
+        return next_fp, next_writer
+
+    try:
+        try:
+            cursor.execute("SET SESSION group_concat_max_len = 1048576")
+        except Exception:
+            pass
+
+        params = [format_datetime(from_utc), format_datetime(to_utc)] + approval_rule_names
+        cursor.execute(sql, params)
+        fp, writer = open_next_file()
+
+        while True:
+            rows = cursor.fetchmany(fetch_size)
+            if not rows:
+                break
+            for row in rows:
+                if rows_per_file > 0 and count > 0 and count % rows_per_file == 0:
+                    fp.close()
+                    fp, writer = open_next_file()
+                write_row(writer, transform_export_row(row), encoding)
+                count += 1
+    finally:
+        cursor.close()
+        if fp is not None:
+            fp.close()
+    return count, output_paths
+
+
+def main():
+    args = parse_args()
+    add_vendor_dir(args.vendor_dir)
+
+    from_kst = parse_kst_datetime(args.from_kst)
+    to_kst = parse_kst_datetime(args.to_kst)
+    if from_kst >= to_kst:
+        raise SystemExit("--from-kst must be earlier than --to-kst")
+
+    from_utc = from_kst - KST_OFFSET
+    to_utc = to_kst - KST_OFFSET
+
+    db_config = DbConfig(
+        host=args.db_host,
+        port=args.db_port,
+        user=args.db_user,
+        password=args.db_password,
+        database=args.db_name,
+    )
+    conn = connect(db_config, streaming=True)
+    try:
+        count, output_paths = export_rows(
+            conn,
+            args.output,
+            from_utc,
+            to_utc,
+            args.encoding,
+            args.fetch_size,
+            args.rows_per_file,
+            args.approval_rule_name,
+        )
+    finally:
+        conn.close()
+
+    print("from_kst: %s" % format_datetime(from_kst))
+    print("to_kst: %s" % format_datetime(to_kst))
+    print("from_utc: %s" % format_datetime(from_utc))
+    print("to_utc: %s" % format_datetime(to_utc))
+    print("exported rows: %s" % count)
+    if args.approval_rule_name:
+        print("approval_rule_names: %s" % ", ".join(args.approval_rule_name))
+    print("output files: %s" % len(output_paths))
+    for output_path in output_paths:
+        print("output: %s" % output_path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/querypie-report/workflow_sql_history/README.md
+++ b/querypie-report/workflow_sql_history/README.md
@@ -1,0 +1,95 @@
+# Workflow SQL 이력 조회
+
+SQL 실행 Workflow의 DML 실행 이력과 승인 처리 이력을 조회하는 SQL 모음입니다. 모두 읽기 전용이며 App DB(`querypie`)와 Log DB(`querypie_log`)에 대한 조회 권한이 필요합니다.
+
+## 파일 선택
+
+| 파일 | 사용 목적 | 주요 입력 |
+| --- | --- | --- |
+| `successful_dml_requests.sql` | 성공한 SQL Workflow의 `INSERT`·`UPDATE`·`DELETE` 실행 이력 | 시작 시각, 종료 시각 |
+| `ledger_dml_requests.sql` | Ledger로 표시된 SQL Workflow의 `INSERT`·`UPDATE`·`DELETE` 실행 이력 | 시작 시각, 종료 시각 |
+| `approvals_by_approver.sql` | 특정 승인자가 승인 처리한 SQL Workflow 이력 | 시작 시각, 종료 시각, 승인자 이메일 |
+
+## 공통 실행 방법
+
+조회하려는 파일 상단의 변수를 수정한 뒤 QueryPie App DB에 연결하여 실행합니다. DML 실행 이력 SQL은 다음처럼 종료 시각을 **미포함**으로 사용합니다.
+
+```sql
+SET @start_kst = '2026-01-01 00:00:00';
+SET @end_kst = '2026-04-01 00:00:00';
+```
+
+위 예시는 2026-01-01 00:00:00 이상, 2026-04-01 00:00:00 미만을 의미합니다. 월 단위 추출 시 다음 달 1일을 종료값으로 두면 안전합니다. `approvals_by_approver.sql`은 종료 시각을 포함하는 `<=` 조건을 사용합니다.
+
+`@start_kst`, `@end_kst`는 KST 기준 입력값입니다. SQL은 UTC로 저장된 `requested_at`과 비교할 때 9시간을 빼며, 출력 시각에는 9시간을 더해 KST로 표시합니다.
+
+## `successful_dml_requests.sql`
+
+`request_type = 'SQL_EXECUTION'`, `execution_status = 'SUCCESS'`인 Workflow와 해당 Workflow에 연결된 Query Audit 실행 로그를 결합합니다. Query 유형 코드가 `INSERT`(3), `UPDATE`(6), `DELETE`(7)인 행만 반환합니다. 하나의 Workflow에 여러 DML 문이 있으면 문장별로 여러 행이 나옵니다.
+
+| 컬럼 | 설명 |
+| --- | --- |
+| `request_id` | Workflow 요청 ID |
+| `request_uuid` | Workflow 요청 UUID |
+| `title` | Workflow 제목 |
+| `requested_at_kst` | Workflow 상신 시각(KST) |
+| `requester_name` | 요청자 이름 |
+| `requester_email` | 요청자 이메일 |
+| `execution_status` | Workflow 실행 상태. 이 SQL에서는 `SUCCESS`만 대상 |
+| `sub_query_index` | 한 요청 안에서 실행된 SQL 문장의 순번 |
+| `executed_at_kst` | 해당 SQL 문장 실행 시각(KST) |
+| `sql_type` | DML 유형(`INSERT`/`UPDATE`/`DELETE`) |
+| `executed_query` | 실제 실행된 SQL 전문 |
+| `processed_rows` | 처리된 행 수. 값이 없으면 `0` |
+| `query_result` | Query Audit 실행 결과를 사람이 읽기 쉬운 상태로 변환한 값 |
+
+## `ledger_dml_requests.sql`
+
+`ledger = 1`인 SQL Workflow와 Query Audit 실행 로그를 결합합니다. Workflow의 전체 실행 성공 여부로 제한하지 않으므로, Ledger Workflow에서 기록된 DML 실행 행을 폭넓게 확인할 때 사용합니다. Query 유형 코드가 `INSERT`(3), `UPDATE`(6), `DELETE`(7)인 행만 반환합니다.
+
+| 컬럼 | 설명 |
+| --- | --- |
+| `request_id` | Workflow 요청 ID |
+| `request_uuid` | Workflow 요청 UUID |
+| `title` | Workflow 제목 |
+| `requested_at_kst` | Workflow 상신 시각(KST) |
+| `requester_name` | 요청자 이름 |
+| `requester_email` | 요청자 이메일 |
+| `execution_status` | Workflow 실행 상태 |
+| `sub_query_index` | 한 요청 안에서 실행된 SQL 문장의 순번 |
+| `executed_at_kst` | 해당 SQL 문장 실행 시각(KST) |
+| `sql_type` | DML 유형(`INSERT`/`UPDATE`/`DELETE`) |
+| `executed_query` | 실제 실행된 SQL 전문 |
+| `processed_rows` | 처리된 행 수. 값이 없으면 `0` |
+
+## `approvals_by_approver.sql`
+
+특정 승인자가 `WORKFLOW_APPROVED` 이벤트를 처리한 SQL Workflow 이력을 조회합니다. SQL 상단에서 승인자 이메일과 기간을 수정합니다.
+
+```sql
+SET @start_kst = '2024-01-01 00:00:00';
+SET @end_kst = '2024-12-31 23:59:59';
+SET @approver_email = 'approver@example.com';
+```
+
+승인자가 같은 Workflow에서 여러 승인 이벤트를 처리했다면 이벤트별로 여러 행이 나올 수 있습니다. 이 SQL은 승인 이력만 조회하며, 해당 Workflow에서 실행된 SQL 전문이나 DML 여부는 출력하지 않습니다.
+
+| 컬럼 | 설명 |
+| --- | --- |
+| `requested_at_kst` | Workflow 상신 시각(KST) |
+| `title` | Workflow 제목 |
+| `requester_name` | 요청자 이름 |
+| `requester_email` | 요청자 이메일 |
+| `requester_login_id` | 요청자 Login ID |
+| `approval_status` | Workflow의 현재 승인 상태 |
+| `approver_name` | 승인 처리한 사용자 이름 |
+| `approver_email` | 승인 처리한 사용자 이메일 |
+| `approver_login_id` | 승인 처리한 사용자 Login ID |
+| `approved_at_kst` | 승인 이벤트 처리 시각(KST) |
+| `approval_comments` | 승인 처리 시 입력한 의견 |
+
+## 유의 사항
+
+- `executed_query`에는 민감한 조건값 또는 개인정보가 포함될 수 있습니다. 결과 파일의 열람·보관 권한을 관리하세요.
+- DML 유형은 Query Audit의 `query_type` 코드에 의존합니다. 다른 DB 유형이나 제품 버전에서 코드 체계가 다르면 `CASE` 조건을 확인하세요.
+- 승인 이력은 Log DB의 이벤트를 기준으로 하므로, Workflow의 현재 상태와 과거 승인 이벤트가 서로 다를 수 있습니다.

--- a/querypie-report/workflow_sql_history/approvals_by_approver.sql
+++ b/querypie-report/workflow_sql_history/approvals_by_approver.sql
@@ -1,0 +1,21 @@
+SET @start_kst = '2024-01-01 00:00:00';
+SET @end_kst = '2024-12-31 23:59:59';
+SET @approver_email = CONVERT('approver@example.com' USING utf8mb4) COLLATE utf8mb4_general_ci;
+
+SELECT
+    DATE_ADD(wr.requested_at, INTERVAL 9 HOUR) AS requested_at_kst,
+    wr.title, wr.requester_name, wr.requester_email,
+    wr.requester_login_id, wr.approval_status,
+    approver.user_name AS approver_name, approver.user_email AS approver_email,
+    approver.user_login_id AS approver_login_id,
+    DATE_ADD(wl.acted_at, INTERVAL 9 HOUR) AS approved_at_kst,
+    wl.comments AS approval_comments
+FROM querypie.workflow_requests wr
+JOIN querypie_log.l_workflow_logs wl ON wl.workflow_uuid = wr.uuid
+JOIN querypie_log.l_user_snapshots approver ON approver.id = wl.actor_snapshot_id
+WHERE wr.request_type = 'SQL_EXECUTION'
+  AND wl.action_type = 'WORKFLOW_APPROVED'
+  AND wr.requested_at >= DATE_SUB(@start_kst, INTERVAL 9 HOUR)
+  AND wr.requested_at <= DATE_SUB(@end_kst, INTERVAL 9 HOUR)
+  AND approver.user_email = @approver_email
+ORDER BY wr.requested_at DESC;

--- a/querypie-report/workflow_sql_history/ledger_dml_requests.sql
+++ b/querypie-report/workflow_sql_history/ledger_dml_requests.sql
@@ -1,0 +1,20 @@
+-- Ledger SQL Workflow requests with INSERT, UPDATE, and DELETE audits.
+SET @start_kst = '2026-01-01 00:00:00';
+SET @end_kst = '2026-04-01 00:00:00';
+
+SELECT
+    wr.id AS request_id, wr.uuid AS request_uuid, wr.title,
+    DATE_ADD(wr.requested_at, INTERVAL 9 HOUR) AS requested_at_kst,
+    wr.requester_name, wr.requester_email, wr.execution_status,
+    qel.query_request_sub_query_index AS sub_query_index,
+    DATE_ADD(qel.executed_at, INTERVAL 9 HOUR) AS executed_at_kst,
+    CASE qel.query_type WHEN 3 THEN 'INSERT' WHEN 6 THEN 'UPDATE' WHEN 7 THEN 'DELETE' ELSE 'OTHER' END AS sql_type,
+    qel.query_text AS executed_query, COALESCE(qel.processed_record_count, 0) AS processed_rows
+FROM querypie.workflow_requests wr
+JOIN querypie_log.l_query_execution_logs qel ON qel.query_request_uuid = wr.uuid
+WHERE wr.request_type = 'SQL_EXECUTION'
+  AND wr.ledger = 1
+  AND wr.requested_at >= DATE_SUB(@start_kst, INTERVAL 9 HOUR)
+  AND wr.requested_at < DATE_SUB(@end_kst, INTERVAL 9 HOUR)
+  AND qel.query_type IN (3, 6, 7)
+ORDER BY wr.requested_at ASC, qel.query_request_sub_query_index ASC;

--- a/querypie-report/workflow_sql_history/successful_dml_requests.sql
+++ b/querypie-report/workflow_sql_history/successful_dml_requests.sql
@@ -1,0 +1,21 @@
+-- Successful SQL Workflow requests with INSERT, UPDATE, and DELETE audits.
+SET @start_kst = '2026-01-01 00:00:00';
+SET @end_kst = '2026-04-01 00:00:00';
+
+SELECT
+    wr.id AS request_id, wr.uuid AS request_uuid, wr.title,
+    DATE_ADD(wr.requested_at, INTERVAL 9 HOUR) AS requested_at_kst,
+    wr.requester_name, wr.requester_email, wr.execution_status,
+    qel.query_request_sub_query_index AS sub_query_index,
+    DATE_ADD(qel.executed_at, INTERVAL 9 HOUR) AS executed_at_kst,
+    CASE qel.query_type WHEN 3 THEN 'INSERT' WHEN 6 THEN 'UPDATE' WHEN 7 THEN 'DELETE' ELSE 'OTHER' END AS sql_type,
+    qel.query_text AS executed_query, COALESCE(qel.processed_record_count, 0) AS processed_rows,
+    CASE qel.state WHEN 1 THEN 'SUCCESS' WHEN 2 THEN 'FAILURE' WHEN 3 THEN 'STOPPED' WHEN 5 THEN 'RUNNING' WHEN 6 THEN 'ABORTED' ELSE 'UNKNOWN' END AS query_result
+FROM querypie.workflow_requests wr
+JOIN querypie_log.l_query_execution_logs qel ON qel.query_request_uuid = wr.uuid
+WHERE wr.request_type = 'SQL_EXECUTION'
+  AND wr.execution_status = 'SUCCESS'
+  AND wr.requested_at >= DATE_SUB(@start_kst, INTERVAL 9 HOUR)
+  AND wr.requested_at < DATE_SUB(@end_kst, INTERVAL 9 HOUR)
+  AND qel.query_type IN (3, 6, 7)
+ORDER BY wr.requested_at DESC, qel.query_request_sub_query_index ASC;


### PR DESCRIPTION
## Summary
- Add a Python 2.7-compatible Workflow SQL audit CSV exporter with optional Ledger and DML Snapshot enrichment.
- Add SQL reports for Query Audit, Workflow history, Ledger policies and DML counts, user history, access control, and Activity Log changes.
- Add repository and per-directory documentation, including UTC storage / KST input-output conventions.

## Test Plan
- Ran git diff --check.
- Validated Python source syntax for Python 2.7 compatibility during implementation.
- Verified SQL/documentation input, output-column, and time-zone descriptions statically.

## Notes
- SQL reports are read-only.
- DML Snapshot export remains opt-in.