### PR TITLE
feat(aws/ami): Marketplace 이미지 생성 단계 정비

### DIFF
--- a/aws/ami/ami-build.pkr.hcl
+++ b/aws/ami/ami-build.pkr.hcl
@@ -107,8 +107,13 @@ data "amazon-ami" "amazon-linux-2023" {
 # amazon-ebs : Type of builder, or plugin name
 # amazon-linux-2023 : Name of the builder
 source "amazon-ebs" "amazon-linux-2023" {
-  source_ami = data.amazon-ami.amazon-linux-2023.id
-  ami_name   = local.ami_name
+  source_ami              = data.amazon-ami.amazon-linux-2023.id
+  ami_name                = local.ami_name
+  ami_description         = "QueryPie Suite ${var.querypie_version} on Amazon Linux 2023"
+  ami_virtualization_type = "hvm"
+  ena_support             = true
+  encrypt_boot            = false
+  imds_support            = "v2.0"
 
   region       = local.region
   ssh_username = local.ssh_username
@@ -132,7 +137,7 @@ source "amazon-ebs" "amazon-linux-2023" {
     iops = 16000 # Max: 16000 IOPS for gp3
     throughput = 1000  # Max: 1000 MiB/s throughput
     delete_on_termination = true
-    encrypted             = true
+    encrypted             = false
   }
 
   # Instance metadata options
@@ -213,20 +218,14 @@ build {
     ]
   }
 
-  # Final cleanup
+  # Marketplace source AMIs cannot contain encrypted file systems.
   provisioner "shell" {
-    inline_shebang = "/bin/bash -ex"
-    inline = [
-      "echo '# Performing final cleanup...'",
-      "sudo dnf clean all",
-      "sudo rm -rf /tmp/*",
-      "sudo rm -rf /var/tmp/*",
-      "history -c",
-      "cat /dev/null > ~/.bash_history",
-      "sudo rm -f /root/.bash_history",
-      "sudo find /var/log -type f -exec truncate -s 0 {} \\;",
-      "echo 'Cleanup completed'"
-    ]
+    script = "validate-image-runtime.sh"
+  }
+
+  # Harden and sanitize the image as the final provisioning step.
+  provisioner "shell" {
+    script = "sanitize-image-before-snapshot.sh"
   }
 
   # Generate manifest

--- a/aws/ami/sanitize-image-before-snapshot.sh
+++ b/aws/ami/sanitize-image-before-snapshot.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -o nounset -o errexit -o errtrace -o pipefail
+
+echo "### Sanitize the image before creating the AMI snapshot"
+
+# Disable every form of password-based SSH authentication and direct root login.
+sudo mkdir -p /etc/ssh/sshd_config.d
+printf '%s\n' \
+  'PasswordAuthentication no' \
+  'KbdInteractiveAuthentication no' \
+  'PermitRootLogin no' |
+  sudo tee /etc/ssh/sshd_config.d/99-querypie-marketplace.conf >/dev/null
+sudo passwd --lock root
+sudo sshd -t
+
+# Build-time keys must never be included in an image delivered to customers.
+sudo find /root /home -xdev -type f -name authorized_keys -delete
+sudo find /etc/ssh -maxdepth 1 -type f -name 'ssh_host_*_key*' -delete
+
+# Force cloud-init and systemd to initialize per-instance state on the next boot.
+sudo cloud-init clean --logs --machine-id
+sudo rm -f /var/lib/systemd/random-seed
+
+# Remove build caches, temporary files, histories, and logs.
+sudo dnf clean all
+sudo find /tmp /var/tmp -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +
+sudo find /root /home -xdev -type f -name '.*history' -delete
+sudo find /var/log -type f -exec truncate -s 0 {} +
+
+if sudo find /root /home -xdev -type f -name authorized_keys -size +0c | grep -q .; then
+  echo >&2 "ERROR: A non-empty SSH authorized_keys file remains in the image."
+  exit 1
+fi
+
+sync
+echo "### Image sanitization completed"

--- a/aws/ami/tests/ami-runtime-validation.bats
+++ b/aws/ami/tests/ami-runtime-validation.bats
@@ -1,0 +1,42 @@
+#!/usr/bin/env bats
+
+setup() {
+  TEST_ROOT=$(mktemp -d)
+  MOCK_BIN="$TEST_ROOT/bin"
+  mkdir -p "$MOCK_BIN"
+
+  cat >"$MOCK_BIN/lsblk" <<'EOF'
+#!/usr/bin/env bash
+printf '%b' "${MOCK_LSBLK_OUTPUT:-disk\npart xfs\n}"
+EOF
+  chmod +x "$MOCK_BIN/lsblk"
+
+  cat >"$MOCK_BIN/findmnt" <<'EOF'
+#!/usr/bin/env bash
+printf '%b' "${MOCK_FINDMNT_OUTPUT:-xfs\n}"
+EOF
+  chmod +x "$MOCK_BIN/findmnt"
+}
+
+teardown() {
+  rm -rf "$TEST_ROOT"
+}
+
+@test "runtime validation rejects a LUKS-backed image" {
+  run env \
+    PATH="$MOCK_BIN:$PATH" \
+    MOCK_LSBLK_OUTPUT='disk\npart crypto_LUKS\ncrypt xfs\n' \
+    "$BATS_TEST_DIRNAME/../validate-image-runtime.sh"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"encrypted block device or filesystem"* ]]
+}
+
+@test "runtime validation accepts an image without encrypted filesystems" {
+  run env \
+    PATH="$MOCK_BIN:$PATH" \
+    "$BATS_TEST_DIRNAME/../validate-image-runtime.sh"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Image runtime checks completed"* ]]
+}

--- a/aws/ami/validate-image-runtime.sh
+++ b/aws/ami/validate-image-runtime.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -o nounset -o errexit -o errtrace -o pipefail
+
+if lsblk --noheadings --raw --output TYPE,FSTYPE |
+  awk '$1 == "crypt" || $2 == "crypto_LUKS" { found = 1 } END { exit !found }'; then
+  echo >&2 "ERROR: The image contains an encrypted block device or filesystem."
+  exit 1
+fi
+
+if findmnt --noheadings --raw --output FSTYPE |
+  awk '$1 ~ /^(ecryptfs|encfs|fuse\.encfs|fuse\.gocryptfs)$/ { found = 1 } END { exit !found }'; then
+  echo >&2 "ERROR: The image contains an encrypted block device or filesystem."
+  exit 1
+fi
+
+echo "### Image runtime checks completed"


### PR DESCRIPTION
## 기존 문제 (`main` 기준)

- 루트 EBS 볼륨이 암호화되어 비암호화 스냅샷을 요구하는 AWS Marketplace 소스 AMI로 승격할 수 없었습니다.
- 기존 최종 정리는 임시 파일과 로그 일부만 삭제해 authorized key, SSH host key, cloud-init 상태와 machine-id가 이미지에 남을 수 있었습니다.
- AMI 생성 전에 LUKS 및 암호화 게스트 파일시스템이 없는지 확인하지 않았습니다.

## 구현 내용

- Packer가 비암호화 EBS, HVM, ENA, IMDSv2 속성을 가진 AMI를 생성하도록 설정했습니다.
- `validate-image-runtime.sh`가 스냅샷 전에 암호화 블록 장치와 파일시스템을 검사합니다.
- `sanitize-image-before-snapshot.sh`가 SSH 인증 설정, authorized key, SSH host key, cloud-init 상태, machine-id, 로그·캐시·임시 파일을 정리합니다.
- 정리 스크립트는 사용자 명령이 아니라 Packer의 마지막 내부 provisioning 단계로만 실행합니다.

## 검증

- `packer validate -syntax-only aws/ami/ami-build.pkr.hcl`
- `bash -n` 및 `shellcheck` (`sanitize-image-before-snapshot.sh`, `validate-image-runtime.sh`)
- `bats aws/ami/tests/ami-runtime-validation.bats` (2개 통과)
- `git diff --check`

실제 AWS AMI 빌드와 Marketplace 보안 스캔은 비용 및 판매자 포털 접근이 필요해 수행하지 않았습니다.

## 후속 PR

리전·아키텍처 실행 안정성, AWS API 구조 검증, 판매자 계정 승격 문서는 각각 별도 stacked PR로 분리합니다.
