### PR TITLE
chore(aws/ami): AL2023 base AMI 및 선택 필터 갱신

### DIFF
--- a/aws/ami/README.md
+++ b/aws/ami/README.md
@@ -130,7 +130,7 @@ MODE=release ./ami-build.sh 11.6.0
 ami-build.sh 실행
     │
     ▼
-베이스 AMI 탐색 (al2023-ami-2023.10.*)
+베이스 AMI 탐색 (al2023-ami-2023.12.*-kernel-6.12-*)
     │
     ▼
 Spot Fleet 인스턴스 기동 (t3.xlarge, ~$0.078/시간)
@@ -225,14 +225,14 @@ Error: Datasource.Execute failed: No AMI was found matching filters
 ```
 
 `ami-build.pkr.hcl`의 AMI 필터가 오래된 버전을 가리키고 있습니다.
-현재 유효한 필터는 `al2023-ami-2023.10.*`입니다.
+현재 유효한 필터는 `al2023-ami-2023.12.*-kernel-6.12-*`입니다.
 
 현재 사용 가능한 최신 베이스 AMI를 확인하려면:
 
 ```bash
 # x86_64
 aws ec2 describe-images \
-  --filters "Name=name,Values=al2023-ami-2023.*" \
+  --filters "Name=name,Values=al2023-ami-2023.12.*-kernel-6.12-*" \
             "Name=root-device-type,Values=ebs" \
             "Name=virtualization-type,Values=hvm" \
             "Name=architecture,Values=x86_64" \
@@ -242,7 +242,7 @@ aws ec2 describe-images \
 
 # arm64
 aws ec2 describe-images \
-  --filters "Name=name,Values=al2023-ami-2023.*" \
+  --filters "Name=name,Values=al2023-ami-2023.12.*-kernel-6.12-*" \
             "Name=root-device-type,Values=ebs" \
             "Name=virtualization-type,Values=hvm" \
             "Name=architecture,Values=arm64" \

--- a/aws/ami/ami-build.pkr.hcl
+++ b/aws/ami/ami-build.pkr.hcl
@@ -79,15 +79,15 @@ locals {
 # amazon-ami : Type of data source, or plugin name
 # amazon-linux-2023 : Name of the data source
 ###
-# aws ec2 describe-images --image-ids ami-00aa851417c591bb3
-# "Name": "al2023-ami-2023.10.20260302.1-kernel-6.12-x86_64"
-# "Description": "Amazon Linux 2023 AMI 2023.10.20260302.1 x86_64 HVM kernel-6.12"
+# aws ec2 describe-images --image-ids ami-02ee6d86e720aef2a
+# "Name": "al2023-ami-2023.12.20260727.0-kernel-6.12-x86_64"
+# "Description": "Amazon Linux 2023 AMI 2023.12.20260727.0 x86_64 HVM kernel-6.12"
 # "Architecture": "x86_64"
 # "DeviceName": "/dev/xvda"
 ###
-# aws ec2 describe-images --image-ids ami-0257962c1c28dd1ad
-# "Name": "al2023-ami-2023.10.20260105.0-kernel-6.12-arm64"
-# "Description": "Amazon Linux 2023 AMI 2023.10.20260105.0 arm64 HVM kernel-6.12"
+# aws ec2 describe-images --image-ids ami-0fd5a0021a051a02b
+# "Name": "al2023-ami-2023.12.20260727.0-kernel-6.12-arm64"
+# "Description": "Amazon Linux 2023 AMI 2023.12.20260727.0 arm64 HVM kernel-6.12"
 # "Architecture": "arm64"
 # "DeviceName": "/dev/xvda"
 data "amazon-ami" "amazon-linux-2023" {

--- a/aws/ami/ami-build.pkr.hcl
+++ b/aws/ami/ami-build.pkr.hcl
@@ -79,20 +79,20 @@ locals {
 # amazon-ami : Type of data source, or plugin name
 # amazon-linux-2023 : Name of the data source
 ###
-# aws ec2 describe-images --image-ids ami-02ee6d86e720aef2a
-# "Name": "al2023-ami-2023.12.20260727.0-kernel-6.12-x86_64"
-# "Description": "Amazon Linux 2023 AMI 2023.12.20260727.0 x86_64 HVM kernel-6.12"
+# aws ec2 describe-images --image-ids ami-06882388850fd4a12
+# "Name": "al2023-ami-2023.12.20260803.3-kernel-6.12-x86_64"
+# "Description": "Amazon Linux 2023 AMI 2023.12.20260803.3 x86_64 HVM kernel-6.12"
 # "Architecture": "x86_64"
 # "DeviceName": "/dev/xvda"
 ###
-# aws ec2 describe-images --image-ids ami-0fd5a0021a051a02b
-# "Name": "al2023-ami-2023.12.20260727.0-kernel-6.12-arm64"
-# "Description": "Amazon Linux 2023 AMI 2023.12.20260727.0 arm64 HVM kernel-6.12"
+# aws ec2 describe-images --image-ids ami-0a5d374fd3072c21c
+# "Name": "al2023-ami-2023.12.20260803.3-kernel-6.12-arm64"
+# "Description": "Amazon Linux 2023 AMI 2023.12.20260803.3 arm64 HVM kernel-6.12"
 # "Architecture": "arm64"
 # "DeviceName": "/dev/xvda"
 data "amazon-ami" "amazon-linux-2023" {
   filters = {
-    name                = "al2023-ami-2023.10.*"
+    name                = "al2023-ami-2023.12.*-kernel-6.12-*"
     root-device-type    = "ebs"
     virtualization-type = "hvm"
     architecture        = var.architecture == "arm64" ? "arm64" : "x86_64"


### PR DESCRIPTION
## 기존 문제

- `ami-build.pkr.hcl`의 AMI 예시는 AL2023 `2023.12`를 가리키지만, 실제 data source 필터는 `2023.10.*`에 머물러 있었습니다.
- 버전만 `2023.12`로 넓히면 arm64에서 kernel 6.18 이미지가 선택될 수 있어, PR이 의도한 안정 kernel 6.12 기준과 달라질 수 있었습니다.
- 빌드 가이드의 활성 필터와 조회 명령도 기존 `2023.10` 기준이었습니다.

## 변경 내용

- Packer 필터를 `al2023-ami-2023.12.*-kernel-6.12-*`로 갱신합니다.
- 서울 리전에서 2026-08-05에 조회한 최신 AL2023 `2023.12` kernel 6.12 AMI로 예시를 갱신합니다.
  - x86_64: `ami-06882388850fd4a12` (`al2023-ami-2023.12.20260803.3-kernel-6.12-x86_64`)
  - arm64: `ami-0a5d374fd3072c21c` (`al2023-ami-2023.12.20260803.3-kernel-6.12-arm64`)
- `aws/ami/README.md`의 빌드 흐름, 활성 필터, 조회 예시를 동일한 기준으로 맞춥니다.

## 확인 근거

- AWS EC2 `DescribeImages`를 서울 리전(`ap-northeast-2`)에서 실행해 두 이미지의 ID, Name, Description, Architecture, CreationDate, Available 상태를 확인했습니다.
- `owners = ["amazon"]`, EBS, HVM, architecture 조건과 새 name 필터를 조합했을 때 각 아키텍처에서 위 kernel 6.12 이미지가 최신 결과로 선택됨을 확인했습니다.

## 검증

- `packer validate ami-build.pkr.hcl` 통과
- `packer validate -syntax-only aws/ami/ami-build.pkr.hcl` 통과
- `git diff --check` 통과
- `packer fmt -check -diff ami-build.pkr.hcl`은 `origin/main`부터 존재한 정렬 차이만 보고하며, 이번 변경 범위에는 포맷 전면 수정이 포함되지 않습니다.
- 실제 AMI 빌드는 비용과 실행 시간이 발생하므로 수행하지 않았습니다.