### PR TITLE
[1/3] fix(aws/ami): 빌드 리전과 아키텍처 전달 일관성 보장

### DIFF
--- a/aws/ami/ami-build.pkr.hcl
+++ b/aws/ami/ami-build.pkr.hcl
@@ -23,9 +23,20 @@ variable "ami_name" {
 }
 
 variable "architecture" {
-  type = string
-  default = "x86_64"
+  type        = string
+  default     = "x86_64"
   description = "x86_64 | arm64"
+
+  validation {
+    condition     = contains(["x86_64", "arm64"], var.architecture)
+    error_message = "Architecture must be either x86_64 or arm64."
+  }
+}
+
+variable "region" {
+  type        = string
+  default     = "ap-northeast-2"
+  description = "AWS Region where Packer builds the AMI"
 }
 
 variable "resource_owner" {
@@ -37,10 +48,8 @@ variable "resource_owner" {
 # Local variables
 locals {
   timestamp = regex_replace(timestamp(), "[- TZ:]", "")
-  ami_name = "${var.ami_name}"
+  ami_name = var.ami_name
 
-  region = "ap-northeast-2"
-  instance_type = "t3.xlarge" # Use t3.xlarge to accelerate the build process
   ssh_username = "ec2-user" # SSH username for Amazon Linux 2023
 
   common_tags = {
@@ -99,7 +108,7 @@ data "amazon-ami" "amazon-linux-2023" {
   }
   most_recent = true
   owners = ["amazon"]
-  region      = local.region
+  region      = var.region
 }
 
 # Builder Configuration
@@ -115,16 +124,12 @@ source "amazon-ebs" "amazon-linux-2023" {
   encrypt_boot            = false
   imds_support            = "v2.0"
 
-  region       = local.region
+  region       = var.region
   ssh_username = local.ssh_username
   # ssh_private_key_file = "demo-targets.pem"
   # ssh_keypair_name = "demo-targets"
 
-  # spot_instance_types = ["t4g.xlarge"]
   spot_instance_types = var.architecture == "arm64" ? ["t4g.xlarge"] : ["t3.xlarge"]
-  spot_price = "0.09" # the maximum hourly price
-  # $0.0646 for t4g.xlarge instance in ap-northeast-2
-  # $0.078 for t3.xlarge instance
 
   # EBS configuration
   ebs_optimized = true
@@ -148,7 +153,7 @@ source "amazon-ebs" "amazon-linux-2023" {
   }
 
   # Security group configuration
-  temporary_security_group_source_cidrs = ["0.0.0.0/0"]
+  temporary_security_group_source_public_ip = true
 
   # Tags of the EC2 instance used for building the AMI
   run_tags = local.instance_tags
@@ -237,6 +242,8 @@ build {
       querypie_version = var.querypie_version
       timestamp        = local.timestamp
       base_ami         = data.amazon-ami.amazon-linux-2023.name
+      region           = var.region
+      architecture     = var.architecture
     }
   }
 }

--- a/aws/ami/ami-build.sh
+++ b/aws/ami/ami-build.sh
@@ -6,6 +6,9 @@ BOLD_CYAN="\e[1;36m"
 BOLD_RED="\e[1;91m"
 RESET="\e[0m"
 
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+cd "$SCRIPT_DIR"
+
 function log::do() {
   local line_no
   line_no=$(caller | awk '{print $1}')
@@ -20,18 +23,17 @@ function log::error() {
 }
 
 function packer::build() {
-  local version=$1 distro=$2 architecture=$3 ami_name=$4 packer_option="${PACKER_OPTION:-}"
+  local version=$1 architecture=$2 ami_name=$3 region=$4 packer_option="${PACKER_OPTION:-}"
   # NOTE(JK): Use `PACKER_OPTION=-on-error=abort` to allow debugging the AMI build process.
   echo >&2 "### Build AMI with Packer ###"
   echo >&2 "PACKER_OPTION: $packer_option"
-
-  # TODO(JK): distro does not work yet.
 
   # Disable SC2086(Use double quotes to prevent word splitting) to allow expansion of variables.
   # shellcheck disable=SC2086
   log::do packer build \
     -var "querypie_version=$version" \
     -var "architecture=${architecture}" \
+    -var "region=${region}" \
     -var "resource_owner=${USER:-Unknown}" \
     -var "ami_name=$ami_name" \
     -timestamp-ui \
@@ -42,16 +44,18 @@ function packer::build() {
 }
 
 function aws::image_id() {
-  local ami_name=$1
+  local ami_name=$1 region=$2
   echo >&2 "### Get AMI ID ###"
   log::do aws ec2 describe-images \
+    --region "$region" \
     --owners self \
     --filters "Name=name,Values=$ami_name" \
-    --query 'Images[0].ImageId' \
+    --query 'sort_by(Images, &CreationDate)[-1].ImageId' \
     --output text
 }
 
 function validate_environment() {
+  local region=$1
   if ! command -v packer &>/dev/null; then
     log::error "Packer is not installed. Please install Packer to continue."
     exit 1
@@ -61,10 +65,24 @@ function validate_environment() {
     log::error "AWS CLI is not installed. Please install AWS CLI to continue."
     exit 1
   fi
+
+  log::do aws sts get-caller-identity --output text >/dev/null
+
+  local encryption_by_default
+  encryption_by_default=$(aws ec2 get-ebs-encryption-by-default \
+    --region "$region" \
+    --query EbsEncryptionByDefault \
+    --output text)
+  if [[ "$encryption_by_default" != "False" ]]; then
+    log::error "EBS encryption by default must be disabled in $region for Marketplace-bound AMIs."
+    log::error "Current value: $encryption_by_default"
+    exit 1
+  fi
 }
 
 function main() {
   local querypie_version=${1:-} distro=${2:-amazon-linux-2023} architecture=${3:-x86_64}
+  local region=${AMI_REGION:-ap-northeast-2}
   if [[ -z "$querypie_version" ]]; then
     cat <<END_OF_USAGE
 Usage: $0 <querypie_version> [<distro>] [<architecture>]
@@ -72,15 +90,26 @@ Usage: $0 <querypie_version> [<distro>] [<architecture>]
 EXAMPLE:
   $0 11.0.1 amazon-linux-2023
   $0 11.0.1 amazon-linux-2023 arm64
-  $0 11.0.1 ubuntu-24.04
-  $0 11.0.1 ubuntu-22.04
   PACKER_OPTION=-on-error=abort $0 11.0.1 amazon-linux-2023
 
 END_OF_USAGE
     exit 1
   fi
 
-  validate_environment
+  if [[ "$distro" != "amazon-linux-2023" ]]; then
+    log::error "Only amazon-linux-2023 is supported, not $distro."
+    exit 1
+  fi
+
+  case "$architecture" in
+  x86_64 | arm64) ;;
+  *)
+    log::error "Architecture must be x86_64 or arm64, not $architecture."
+    exit 1
+    ;;
+  esac
+
+  validate_environment "$region"
 
   local timestamp ami_name
   timestamp=$(date +%Y%m%d%H%M)
@@ -90,10 +119,14 @@ END_OF_USAGE
     ami_name="QueryPie-Suite-${querypie_version}-${timestamp}"
   fi
 
-  packer::build "$querypie_version" "$distro" "$architecture" "${ami_name}"
+  packer::build "$querypie_version" "$architecture" "${ami_name}" "$region"
 
   local image_id
-  image_id=$(aws::image_id "$ami_name")
+  image_id=$(aws::image_id "$ami_name" "$region")
+  if [[ -z "$image_id" || "$image_id" == "None" ]]; then
+    log::error "The completed build did not produce an AMI named $ami_name in $region."
+    exit 1
+  fi
   echo "Built AMI: $image_id"
 }
 

--- a/aws/ami/ami-verify.pkr.hcl
+++ b/aws/ami/ami-verify.pkr.hcl
@@ -15,14 +15,30 @@ variable "source_ami" {
   description = "ID of the AMI to verify"
 }
 
+variable "architecture" {
+  type        = string
+  default     = "x86_64"
+  description = "Architecture of the AMI to verify"
+
+  validation {
+    condition     = contains(["x86_64", "arm64"], var.architecture)
+    error_message = "Architecture must be either x86_64 or arm64."
+  }
+}
+
+variable "region" {
+  type        = string
+  default     = "ap-northeast-2"
+  description = "Region containing the AMI to verify"
+}
+
 # Local variables
 locals {
-  timestamp = regex_replace(timestamp(), "[- TZ:]", "")
-  source_ami = var.source_ami
-  ami_name   = "QueryPie-Suite-Verification-${local.timestamp}"
+  timestamp     = regex_replace(timestamp(), "[- TZ:]", "")
+  source_ami    = var.source_ami
+  ami_name      = "QueryPie-Suite-Verification-${local.timestamp}"
+  instance_type = var.architecture == "arm64" ? "t4g.xlarge" : "t3.xlarge"
 
-  region = "ap-northeast-2"
-  instance_type = "t3.xlarge" # Use t3.xlarge to accelerate the build process
   ssh_username = "ec2-user" # SSH username for Amazon Linux 2023
 
   common_tags = {
@@ -49,14 +65,13 @@ source "amazon-ebs" "ami-verify" {
   source_ami      = local.source_ami
   ami_name        = local.ami_name
 
-  region        = local.region
+  region        = var.region
   instance_type = local.instance_type
   ssh_username = local.ssh_username
 
   # EBS configuration
   ebs_optimized = true
   ena_support   = true
-  sriov_support = true
 
   # Root volume configuration
   launch_block_device_mappings {
@@ -66,7 +81,8 @@ source "amazon-ebs" "ami-verify" {
     iops = 16000 # Max: 16000 IOPS for gp3
     throughput = 1000  # Max: 1000 MiB/s throughput
     delete_on_termination = true
-    encrypted             = true
+    # The verification volume is temporary and is not submitted to Marketplace.
+    encrypted = true
   }
 
   # Instance metadata options
@@ -77,7 +93,7 @@ source "amazon-ebs" "ami-verify" {
   }
 
   # Security group configuration
-  temporary_security_group_source_cidrs = ["0.0.0.0/0"]
+  temporary_security_group_source_public_ip = true
 
   # Tags of the EC2 instance used for building the AMI
   run_tags = local.instance_tags
@@ -122,6 +138,11 @@ build {
     ]
   }
 
+  # API-level AMI inspection cannot detect encrypted guest file systems.
+  provisioner "shell" {
+    script = "validate-image-runtime.sh"
+  }
+
   # Generate manifest
   post-processor "manifest" {
     output     = "manifest.json"
@@ -129,6 +150,7 @@ build {
     custom_data = {
       timestamp = local.timestamp
       ami_name  = local.ami_name
+      region    = var.region
     }
   }
 }

--- a/aws/ami/ami-verify.sh
+++ b/aws/ami/ami-verify.sh
@@ -6,6 +6,9 @@ BOLD_CYAN="\e[1;36m"
 BOLD_RED="\e[1;91m"
 RESET="\e[0m"
 
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+cd "$SCRIPT_DIR"
+
 function log::do() {
   local line_no
   line_no=$(caller | awk '{print $1}')
@@ -20,7 +23,7 @@ function log::error() {
 }
 
 function packer::verify() {
-  local ami_id=$1 packer_option="${PACKER_OPTION:-}"
+  local ami_id=$1 region=$2 architecture=$3 packer_option="${PACKER_OPTION:-}"
   # NOTE(JK): Use `PACKER_OPTION=-on-error=abort` to allow debugging the AMI build process.
   echo >&2 "### Verify AMI with Packer ###"
   echo >&2 "PACKER_OPTION: $packer_option"
@@ -29,6 +32,8 @@ function packer::verify() {
   # shellcheck disable=SC2086
   log::do packer build \
     -var "source_ami=$ami_id" \
+    -var "region=$region" \
+    -var "architecture=$architecture" \
     -timestamp-ui \
     ${packer_option} \
     ami-verify.pkr.hcl |
@@ -49,7 +54,7 @@ function validate_environment() {
 }
 
 function main() {
-  local ami_id=${1:-} ami_name timestamp
+  local ami_id=${1:-} region=${AMI_REGION:-ap-northeast-2}
   if [[ -z "$ami_id" ]]; then
     echo "Usage: $0 <ami_id>"
     exit 1
@@ -57,7 +62,15 @@ function main() {
 
   validate_environment
 
-  packer::verify "$ami_id"
+  local architecture
+  architecture=$(aws ec2 describe-images \
+    --region "$region" \
+    --owners self \
+    --image-ids "$ami_id" \
+    --query 'Images[0].Architecture' \
+    --output text)
+
+  packer::verify "$ami_id" "$region" "$architecture"
 }
 
 main "$@"

--- a/aws/ami/tests/ami-build-region.bats
+++ b/aws/ami/tests/ami-build-region.bats
@@ -1,0 +1,66 @@
+#!/usr/bin/env bats
+
+setup() {
+  TEST_ROOT=$(mktemp -d)
+  MOCK_BIN="$TEST_ROOT/bin"
+  mkdir -p "$MOCK_BIN"
+
+  cat >"$MOCK_BIN/aws" <<'EOF'
+#!/usr/bin/env bash
+set -o nounset -o errexit -o pipefail
+
+arguments=" $* "
+
+if [[ "$arguments" == *" sts get-caller-identity "* ]]; then
+  printf 'AROAEXAMPLE\t123456789012\tarn:aws:sts::123456789012:assumed-role/test/session\n'
+elif [[ "$arguments" == *" ec2 get-ebs-encryption-by-default "* ]]; then
+  printf '%s\n' "${MOCK_EBS_ENCRYPTION_BY_DEFAULT:-False}"
+elif [[ "$arguments" == *" ec2 describe-images "* && "$arguments" == *"sort_by(Images"* ]]; then
+  printf 'ami-0123456789abcdef0\n'
+else
+  printf 'Unexpected aws invocation: %s\n' "$*" >&2
+  exit 2
+fi
+EOF
+  chmod +x "$MOCK_BIN/aws"
+
+  cat >"$MOCK_BIN/packer" <<'EOF'
+#!/usr/bin/env bash
+set -o nounset -o errexit -o pipefail
+
+printf '%s\n' "$*" >>"$PACKER_INVOCATIONS_FILE"
+EOF
+  chmod +x "$MOCK_BIN/packer"
+
+  PACKER_INVOCATIONS_FILE="$TEST_ROOT/packer-invocations"
+  export PACKER_INVOCATIONS_FILE
+  : >"$PACKER_INVOCATIONS_FILE"
+}
+
+teardown() {
+  rm -rf "$TEST_ROOT"
+}
+
+@test "AMI build forwards a non-default build region" {
+  run env \
+    PATH="$MOCK_BIN:$PATH" \
+    AMI_REGION=ap-southeast-1 \
+    USER=test-builder \
+    "$BATS_TEST_DIRNAME/../ami-build.sh" 11.6.0 amazon-linux-2023 x86_64
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Built AMI: ami-0123456789abcdef0"* ]]
+  grep -F -- '-var region=ap-southeast-1' "$PACKER_INVOCATIONS_FILE"
+}
+
+@test "AMI build stops before Packer when default EBS encryption is enabled" {
+  run env \
+    PATH="$MOCK_BIN:$PATH" \
+    AMI_REGION=ap-northeast-2 \
+    MOCK_EBS_ENCRYPTION_BY_DEFAULT=True \
+    "$BATS_TEST_DIRNAME/../ami-build.sh" 11.6.0 amazon-linux-2023 x86_64
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"EBS encryption by default must be disabled"* ]]
+  [ ! -s "$PACKER_INVOCATIONS_FILE" ]
+}


### PR DESCRIPTION
## Stack

이 PR은 AWS Marketplace AMI 작업의 활성 stack 중 **1/3**입니다.

- [x] [#140 Marketplace 이미지 생성 단계 정비](https://github.com/querypie/tpm/pull/140) — `main`에 병합됨
- [ ] **[#142 빌드 리전과 아키텍처 전달](https://github.com/querypie/tpm/pull/142) — 현재 PR (1/3)**
- [ ] [#143 제출 전 AMI 구조 검증](https://github.com/querypie/tpm/pull/143) — #142에 의존 (2/3)
- [ ] [#144 Marketplace 승격 및 제출 절차](https://github.com/querypie/tpm/pull/144) — #143에 의존 (3/3)

병합 순서: **#142 → #143 → #144**

## 리뷰 범위

- Base: `main` (`#140` 반영 완료)
- Head: `codex/ami-region-architecture`
- 이 PR의 고유 변경: 커밋 1개, 파일 5개
- #140의 이미지 생성·정리 변경은 이 PR diff에 포함하지 않습니다.

## 기존 문제

- Packer 템플릿이 서울 리전을 내부 상수로 사용해 다른 빌드 리전을 선택할 수 없었습니다.
- 검증용 인스턴스가 x86_64 타입으로 고정되어 arm64 AMI 검증과 맞지 않았습니다.
- 임시 보안 그룹이 `0.0.0.0/0`에서 SSH 접근을 허용했습니다.
- 선택 리전의 기본 EBS 암호화가 활성화된 경우, 비암호화 Marketplace AMI를 만들 수 없다는 사실을 Packer 실행 전에 알 수 없었습니다.

## 구현 내용

- 빌드와 검증 템플릿에 `region` 및 `architecture` 변수를 추가하고 래퍼에서 일관되게 전달합니다.
- 기본 빌드 리전은 서울이지만 `AMI_REGION`으로 다른 리전을 선택할 수 있습니다.
- arm64 검증에는 `t4g.xlarge`, x86_64에는 `t3.xlarge`를 사용합니다.
- Packer 임시 보안 그룹은 실행자의 현재 공인 IP만 허용합니다.
- 빌드 전에 AWS 자격 증명과 선택 리전의 기본 EBS 암호화 상태를 확인합니다.
- 지원하지 않는 배포판·아키텍처와 생성 결과 AMI 누락을 명시적으로 실패시킵니다.

## 검증

- 빌드·검증 Packer 템플릿 syntax validation
- 관련 셸 스크립트 `bash -n` 및 `shellcheck`
- 런타임·리전 회귀 테스트 4개 통과
- `git diff --check`

실제 리전별 Spot 인스턴스 및 AMI 빌드는 수행하지 않았습니다.
