### PR TITLE
[2/3] feat(aws/ami): 제출 전 AMI 구조 검증 추가

### DIFF
--- a/aws/ami/ami-build.sh
+++ b/aws/ami/ami-build.sh
@@ -127,6 +127,8 @@ END_OF_USAGE
     log::error "The completed build did not produce an AMI named $ami_name in $region."
     exit 1
   fi
+
+  AMI_REGION="$region" ./ami-validate.sh "$image_id"
   echo "Built AMI: $image_id"
 }
 

--- a/aws/ami/ami-validate.sh
+++ b/aws/ami/ami-validate.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+
+set -o nounset -o errexit -o errtrace -o pipefail
+
+BOLD_CYAN="\e[1;36m"
+BOLD_RED="\e[1;91m"
+RESET="\e[0m"
+
+function log::info() {
+  printf "%b%s%b\n" "$BOLD_CYAN" "$*" "$RESET" 1>&2
+}
+
+function log::error() {
+  printf "%bERROR: %s%b\n" "$BOLD_RED" "$*" "$RESET" 1>&2
+}
+
+function validate_environment() {
+  if ! command -v aws &>/dev/null; then
+    log::error "AWS CLI is not installed. Please install AWS CLI to continue."
+    exit 1
+  fi
+}
+
+function validate_value() {
+  local label=$1 actual=$2 expected=$3
+  if [[ "$actual" != "$expected" ]]; then
+    log::error "$label must be '$expected', but found '$actual'."
+    return 1
+  fi
+  printf "%-24s %s\n" "$label" "$actual"
+}
+
+function main() {
+  local marketplace_source=false
+  if [[ "${1:-}" == "--marketplace-source" ]]; then
+    marketplace_source=true
+    shift
+  fi
+
+  local ami_id=${1:-} region=${AMI_REGION:-ap-northeast-2}
+  if [[ -z "$ami_id" ]]; then
+    echo "Usage: $0 [--marketplace-source] <ami_id>"
+    exit 1
+  fi
+
+  validate_environment
+
+  local details state architecture root_device virtualization imds_support description
+  details=$(aws ec2 describe-images \
+    --region "$region" \
+    --owners self \
+    --image-ids "$ami_id" \
+    --query 'Images[0].[State,Architecture,RootDeviceType,VirtualizationType,ImdsSupport,Description]' \
+    --output text)
+
+  if [[ -z "$details" || "$details" == "None" ]]; then
+    log::error "AMI $ami_id was not found in the current AWS account in $region."
+    exit 1
+  fi
+
+  IFS=$'\t' read -r state architecture root_device virtualization imds_support description <<<"$details"
+
+  log::info "### Validate AMI attributes"
+  local status=0
+  printf "%-24s %s\n" "Region" "$region"
+  if [[ "$marketplace_source" == true ]]; then
+    validate_value "Marketplace region" "$region" "us-east-1" || status=$((status + 1))
+  fi
+  validate_value "State" "$state" "available" || status=$((status + 1))
+  validate_value "Root device type" "$root_device" "ebs" || status=$((status + 1))
+  validate_value "Virtualization type" "$virtualization" "hvm" || status=$((status + 1))
+  validate_value "IMDS support" "$imds_support" "v2.0" || status=$((status + 1))
+
+  case "$architecture" in
+  x86_64 | arm64)
+    printf "%-24s %s\n" "Architecture" "$architecture"
+    ;;
+  *)
+    log::error "Architecture must be x86_64 or arm64, but found '$architecture'."
+    status=$((status + 1))
+    ;;
+  esac
+
+  if [[ -z "$description" || "$description" == "None" ]]; then
+    log::error "AMI description must not be empty."
+    status=$((status + 1))
+  else
+    printf "%-24s %s\n" "Description" "$description"
+  fi
+
+  local snapshot_ids snapshot_id encrypted
+  # shellcheck disable=SC2016 # JMESPath uses a literal `null` expression.
+  snapshot_ids=$(aws ec2 describe-images \
+    --region "$region" \
+    --owners self \
+    --image-ids "$ami_id" \
+    --query 'Images[0].BlockDeviceMappings[?Ebs.SnapshotId!=`null`].Ebs.SnapshotId' \
+    --output text)
+
+  if [[ -z "$snapshot_ids" || "$snapshot_ids" == "None" ]]; then
+    log::error "AMI does not have an EBS snapshot."
+    status=$((status + 1))
+  else
+    for snapshot_id in $snapshot_ids; do
+      encrypted=$(aws ec2 describe-snapshots \
+        --region "$region" \
+        --snapshot-ids "$snapshot_id" \
+        --query 'Snapshots[0].Encrypted' \
+        --output text)
+      validate_value "Snapshot $snapshot_id" "$encrypted" "False" || status=$((status + 1))
+    done
+  fi
+
+  local total_ebs_size_gib
+  # shellcheck disable=SC2016 # JMESPath uses a literal `null` expression.
+  total_ebs_size_gib=$(aws ec2 describe-images \
+    --region "$region" \
+    --owners self \
+    --image-ids "$ami_id" \
+    --query 'sum(Images[0].BlockDeviceMappings[?Ebs.SnapshotId!=`null`].Ebs.VolumeSize)' \
+    --output text)
+  if [[ ! "$total_ebs_size_gib" =~ ^[0-9]+$ ]]; then
+    log::error "Total EBS size could not be determined, found '$total_ebs_size_gib'."
+    status=$((status + 1))
+  elif ((total_ebs_size_gib > 5120)); then
+    log::error "Total EBS size must not exceed 5120 GiB, but found $total_ebs_size_gib GiB."
+    status=$((status + 1))
+  else
+    printf "%-24s %s GiB\n" "Total EBS size" "$total_ebs_size_gib"
+  fi
+
+  if ((status > 0)); then
+    log::error "AMI $ami_id failed $status structural validation check(s)."
+    exit 1
+  fi
+
+  if [[ "$marketplace_source" == true ]]; then
+    log::info "AMI $ami_id satisfies the structural checks required before Marketplace scanning."
+  else
+    log::info "AMI $ami_id satisfies the structural checks required before promotion."
+  fi
+}
+
+main "$@"

--- a/aws/ami/ami-verify.sh
+++ b/aws/ami/ami-verify.sh
@@ -62,6 +62,8 @@ function main() {
 
   validate_environment
 
+  AMI_REGION="$region" ./ami-validate.sh "$ami_id"
+
   local architecture
   architecture=$(aws ec2 describe-images \
     --region "$region" \

--- a/aws/ami/tests/ami-build-region.bats
+++ b/aws/ami/tests/ami-build-region.bats
@@ -11,12 +11,20 @@ set -o nounset -o errexit -o pipefail
 
 arguments=" $* "
 
-if [[ "$arguments" == *" sts get-caller-identity "* ]]; then
+if [[ "$arguments" == *" ec2 describe-images "* && "$arguments" == *"State,Architecture,RootDeviceType"* ]]; then
+  printf '%b\n' 'available\tx86_64\tebs\thvm\tv2.0\tQueryPie Suite'
+elif [[ "$arguments" == *" sts get-caller-identity "* ]]; then
   printf 'AROAEXAMPLE\t123456789012\tarn:aws:sts::123456789012:assumed-role/test/session\n'
 elif [[ "$arguments" == *" ec2 get-ebs-encryption-by-default "* ]]; then
   printf '%s\n' "${MOCK_EBS_ENCRYPTION_BY_DEFAULT:-False}"
 elif [[ "$arguments" == *" ec2 describe-images "* && "$arguments" == *"sort_by(Images"* ]]; then
   printf 'ami-0123456789abcdef0\n'
+elif [[ "$arguments" == *" ec2 describe-images "* && "$arguments" == *"VolumeSize"* ]]; then
+  printf '32\n'
+elif [[ "$arguments" == *" ec2 describe-images "* && "$arguments" == *"SnapshotId"* ]]; then
+  printf 'snap-0123456789abcdef0\n'
+elif [[ "$arguments" == *" ec2 describe-snapshots "* ]]; then
+  printf 'False\n'
 else
   printf 'Unexpected aws invocation: %s\n' "$*" >&2
   exit 2

--- a/aws/ami/tests/ami-validate.bats
+++ b/aws/ami/tests/ami-validate.bats
@@ -1,0 +1,85 @@
+#!/usr/bin/env bats
+
+setup() {
+  TEST_ROOT=$(mktemp -d)
+  MOCK_BIN="$TEST_ROOT/bin"
+  mkdir -p "$MOCK_BIN"
+
+  cat >"$MOCK_BIN/aws" <<'EOF'
+#!/usr/bin/env bash
+set -o nounset -o errexit -o pipefail
+
+arguments=" $* "
+
+if [[ "$arguments" == *" ec2 describe-images "* && "$arguments" == *"State,Architecture,RootDeviceType"* ]]; then
+  printf '%b\n' "${MOCK_IMAGE_DETAILS:-available\\tx86_64\\tebs\\thvm\\tv2.0\\tQueryPie Suite}"
+elif [[ "$arguments" == *" ec2 describe-images "* && "$arguments" == *"VolumeSize"* ]]; then
+  printf '%s\n' "${MOCK_TOTAL_EBS_SIZE_GIB:-32}"
+elif [[ "$arguments" == *" ec2 describe-images "* && "$arguments" == *"SnapshotId"* ]]; then
+  printf 'snap-0123456789abcdef0\n'
+elif [[ "$arguments" == *" ec2 describe-snapshots "* ]]; then
+  printf '%s\n' "${MOCK_SNAPSHOT_ENCRYPTED:-False}"
+else
+  printf 'Unexpected aws invocation: %s\n' "$*" >&2
+  exit 2
+fi
+EOF
+  chmod +x "$MOCK_BIN/aws"
+}
+
+teardown() {
+  rm -rf "$TEST_ROOT"
+}
+
+@test "Marketplace source validation rejects AMIs larger than 5 TiB" {
+  run env \
+    PATH="$MOCK_BIN:$PATH" \
+    AMI_REGION=us-east-1 \
+    MOCK_TOTAL_EBS_SIZE_GIB=5121 \
+    "$BATS_TEST_DIRNAME/../ami-validate.sh" --marketplace-source ami-0123456789abcdef0
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Total EBS size"* ]]
+}
+
+@test "general validation accepts a structurally valid AMI outside us-east-1" {
+  run env \
+    PATH="$MOCK_BIN:$PATH" \
+    AMI_REGION=ap-northeast-2 \
+    "$BATS_TEST_DIRNAME/../ami-validate.sh" ami-0123456789abcdef0
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Region"*"ap-northeast-2"* ]]
+}
+
+@test "Marketplace source validation rejects a source outside us-east-1" {
+  run env \
+    PATH="$MOCK_BIN:$PATH" \
+    AMI_REGION=ap-northeast-2 \
+    "$BATS_TEST_DIRNAME/../ami-validate.sh" --marketplace-source ami-0123456789abcdef0
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Marketplace region must be 'us-east-1'"* ]]
+}
+
+@test "Marketplace source validation rejects an encrypted EBS snapshot" {
+  run env \
+    PATH="$MOCK_BIN:$PATH" \
+    AMI_REGION=us-east-1 \
+    MOCK_SNAPSHOT_ENCRYPTED=True \
+    "$BATS_TEST_DIRNAME/../ami-validate.sh" --marketplace-source ami-0123456789abcdef0
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"must be 'False', but found 'True'"* ]]
+}
+
+@test "validation rejects an AMI that is not owned by the active account" {
+  run env \
+    PATH="$MOCK_BIN:$PATH" \
+    AMI_REGION=us-east-1 \
+    MOCK_IMAGE_DETAILS=None \
+    "$BATS_TEST_DIRNAME/../ami-validate.sh" --marketplace-source ami-0123456789abcdef0
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"was not found in the current AWS account"* ]]
+}


### PR DESCRIPTION
## Stack

이 PR은 AWS Marketplace AMI 작업의 **2/3**입니다.

- [x] [#140 Marketplace 이미지 생성 단계 정비](https://github.com/querypie/tpm/pull/140) — `main`에 병합됨
- [x] [#142 빌드 리전과 아키텍처 전달](https://github.com/querypie/tpm/pull/142) — `main`에 병합됨
- [ ] **[#143 제출 전 AMI 구조 검증](https://github.com/querypie/tpm/pull/143) — 현재 PR**
- [ ] [#144 현재 빌드 동작과 검증 경계 문서화](https://github.com/querypie/tpm/pull/144) — #143에 직접 의존

남은 병합 순서: **#143 → #144**

## 리뷰 범위

- Base: `main` (`e665b40`, #142 병합 결과)
- Head: `codex/ami-structural-validation`
- 고유 변경: 커밋 1개, 파일 5개
- #140과 #142의 변경은 이 PR diff에 포함하지 않습니다.

## 기존 문제

- 생성된 AMI가 현재 계정 소유인지, 사용 가능한 상태인지, HVM/EBS-backed/IMDSv2 요구사항을 만족하는지 자동으로 확인하지 않았습니다.
- 연결된 스냅샷의 암호화 여부와 총 EBS 크기 제한을 제출 전에 검사하지 않았습니다.
- 빌드 결과와 판매자 계정의 최종 Marketplace 소스가 서로 다른 리전 제약을 갖는다는 경계가 없었습니다.

## 구현 내용

- `ami-validate.sh`가 AMI 소유권, 상태, 아키텍처, HVM, EBS-backed, IMDSv2, 설명을 검사합니다.
- 연결된 모든 EBS 스냅샷이 비암호화 상태이고 총 `VolumeSize`가 5120 GiB 이하인지 확인합니다.
- 일반 검증은 `AMI_REGION`의 임의 리전을 허용합니다.
- 판매자 계정의 최종 복사본에 `--marketplace-source`를 지정한 경우에만 `us-east-1`을 요구합니다.
- 빌드 및 기능 검증 래퍼가 구조 검증을 먼저 실행하도록 연결했습니다.

## 검증

- 관련 셸 스크립트 `bash -n` 및 ShellCheck 통과
- 빌드·검증 Packer 템플릿 syntax validation 통과
- 런타임·리전·구조 검증 회귀 테스트 9개 통과
- `git diff --check` 통과

실제 AWS 계정의 AMI와 스냅샷 조회는 수행하지 않았습니다.
