### PR TITLE
[3/3] docs(aws/ami): 현재 빌드 동작과 검증 경계 문서화

### DIFF
--- a/aws/ami/README.md
+++ b/aws/ami/README.md
@@ -1,263 +1,293 @@
-# AWS Marketplace AMI 빌드 가이드
+# QueryPie AWS Marketplace AMI
 
-## 개요
+## 문서 범위
 
-이 디렉토리에는 QueryPie AMI를 빌드하고 검증하기 위한 Packer 스크립트가 있습니다.
+이 문서는 `aws/ami` 디렉토리에 구현된 AMI 빌드와 검증의 현재 설정 및 실행 동작을 설명합니다.
+AWS Marketplace 판매자 등록, 계정 간 AMI 공유, 리전 간 AMI 복사, 제품 생성은 이 디렉토리에서 자동화하지 않습니다.
 
-| 파일 | 설명 |
-|------|------|
-| `ami-build.pkr.hcl` | AMI 빌드 Packer 템플릿 (Spot Instance 사용) |
-| `ami-verify.pkr.hcl` | 빌드된 AMI 검증 Packer 템플릿 |
-| `ami-build.sh` | `ami-build.pkr.hcl` 실행 래퍼 스크립트 |
-| `ami-verify.sh` | `ami-verify.pkr.hcl` 실행 래퍼 스크립트 |
-| `querypie-first-boot.service` | AMI 최초 부팅 시 QueryPie 설치를 완료하는 systemd 서비스 |
+## 현재 실행 컨텍스트
 
-## IAM 권한 설정
+QPE의 AMI 빌드는 다음 AWS 컨텍스트를 사용합니다.
 
-### 계정 정보
+| 항목 | 현재 값 |
+|------|---------|
+| AWS 계정 | QPE (`142605707876`) |
+| 기본 빌드 리전 | 서울 (`ap-northeast-2`) |
+| IAM 사용자 | `JK` |
+| IAM ARN | `arn:aws:iam::142605707876:user/JK` |
+| AWS CLI 프로파일 | 저장소에 설정 없음 |
 
-- **AWS 계정 ID**: `142605707876`
-- **리전**: `ap-northeast-2` (서울)
-- **IAM 유저**: `JK`
-
-### PackerAMIBuilder 정책
-
-`JK` IAM 유저에는 `PackerAMIBuilder` 커스텀 정책이 연결되어 있습니다.
-이 정책은 Packer가 AMI 빌드에 필요한 최소 권한만 허용합니다.
-
-```
-arn:aws:iam::142605707876:policy/PackerAMIBuilder
-```
-
-**정책 구성:**
-
-| Sid | 허용 액션 | 용도 |
-|-----|-----------|------|
-| `PackerAMIDataSource` | `ec2:DescribeImages`, `ec2:DescribeRegions`, `ec2:DescribeSubnets` 외 조회성 액션 | 베이스 AMI 탐색, 리소스 상태 조회 |
-| `PackerSpotInstance` | `ec2:CreateFleet`, `ec2:CreateLaunchTemplate`, `ec2:RequestSpotInstances` 외 | Spot Fleet 인스턴스 생성 및 관리 |
-| `PackerInstanceLifecycle` | `ec2:RunInstances`, `ec2:StopInstances`, `ec2:TerminateInstances` 외 | EC2 인스턴스 생명주기 관리 |
-| `PackerSecurityGroup` | `ec2:CreateSecurityGroup`, `ec2:DeleteSecurityGroup`, `ec2:AuthorizeSecurityGroupIngress` 외 | 임시 보안 그룹 생성/삭제 |
-| `PackerKeyPair` | `ec2:CreateKeyPair`, `ec2:DeleteKeyPair` | 임시 SSH 키페어 생성/삭제 |
-| `PackerAMICreate` | `ec2:CreateImage`, `ec2:RegisterImage`, `ec2:ModifyImageAttribute` 외 | AMI 생성 및 속성 수정 |
-| `PackerEBSVolume` | `ec2:CreateVolume`, `ec2:DeleteVolume`, `ec2:AttachVolume`, `ec2:DetachVolume` | EBS 볼륨 관리 |
-| `PackerSnapshot` | `ec2:CreateSnapshot`, `ec2:DeleteSnapshot`, `ec2:ModifySnapshotAttribute` | EBS 스냅샷 관리 |
-| `PackerTags` | `ec2:CreateTags` | 리소스 태그 추가 |
-
-> **참고**: `AmazonEC2FullAccess` 대신 최소 권한 원칙에 따라 커스텀 정책을 사용합니다.
-> 불필요한 VPC 생성/삭제, 인터넷 게이트웨이 등의 권한은 포함되지 않습니다.
-
-### AWS 자격 증명 설정
-
-`JK` IAM 유저의 액세스 키를 `[default]` 프로파일로 설정합니다.
+저장소에는 AWS 자격 증명이나 AWS CLI 프로파일 설정이 포함되어 있지 않습니다.
+모든 스크립트와 Packer는 실행 시점의 AWS 기본 자격 증명 체인을 그대로 사용합니다.
+기본 빌드 리전은 다음 환경 변수로 설정됩니다.
 
 ```bash
-aws configure
-# AWS Access Key ID: <JK 유저의 액세스 키 ID>
-# AWS Secret Access Key: <JK 유저의 시크릿 액세스 키>
-# Default region name: ap-northeast-2
-# Default output format: json
+export AMI_REGION=ap-northeast-2
 ```
 
-설정 확인:
+`ami-build.sh`는 `aws sts get-caller-identity`의 성공 여부만 확인합니다.
+스크립트는 응답의 계정 ID나 IAM ARN이 위 표의 값과 일치하는지 검사하지 않습니다.
+`ami-verify.sh`, `ami-validate.sh`, `ami-ls.sh`도 계정이나 프로파일을 내부에서 변경하지 않습니다.
 
-```bash
-aws sts get-caller-identity
-# 예상 출력:
-# {
-#   "UserId": "AIDASCM7WNJSBH6TKALFI",
-#   "Account": "142605707876",
-#   "Arn": "arn:aws:iam::142605707876:user/JK"
-# }
-```
+## 파일과 호출 관계
 
-## 빌드 환경 준비 (macOS 기준)
+사용자가 직접 실행하는 명령은 다음 네 개입니다.
 
-### 1. AWS CLI 설치
+| 파일 | 현재 동작 |
+|------|-----------|
+| `ami-build.sh` | Packer로 AMI를 생성한 후 `ami-validate.sh`를 실행 |
+| `ami-verify.sh` | `ami-validate.sh`를 실행한 후 해당 AMI로 검증용 EC2 인스턴스를 기동 |
+| `ami-validate.sh` | 현재 계정이 소유한 AMI와 EBS 스냅샷의 구조적 속성을 AWS API로 검사 |
+| `ami-ls.sh` | 현재 AWS CLI 리전에서 소유자와 이름 조건에 맞는 AMI 목록을 출력 |
 
-```bash
-brew install awscli
-aws --version
-```
+다음 파일은 위 명령이 내부에서 사용합니다.
 
-### 2. Packer 설치
+| 파일 | 현재 동작 |
+|------|-----------|
+| `ami-build.pkr.hcl` | 빌드 인스턴스를 생성하고 QueryPie를 부분 설치한 뒤 AMI와 `manifest.json`을 생성 |
+| `ami-verify.pkr.hcl` | 기존 AMI로 검증 인스턴스를 만들고 새 AMI를 생성하지 않은 채 설치 상태를 검사 |
+| `validate-image-runtime.sh` | 인스턴스 내부의 암호화 블록 장치와 암호화 파일시스템을 검사 |
+| `sanitize-image-before-snapshot.sh` | AMI 스냅샷 직전에 SSH, cloud-init, 로그 및 임시 상태를 정리 |
+| `querypie-first-boot.service` | AMI로 만든 인스턴스가 처음 부팅될 때 QueryPie 설치를 재개 |
 
-```bash
-brew tap hashicorp/tap
-brew install hashicorp/tap/packer
-packer --version
-```
+호출 관계는 다음과 같습니다.
 
-### 3. Packer 플러그인 초기화
+```text
+ami-build.sh
+├── ami-build.pkr.hcl
+│   ├── validate-image-runtime.sh
+│   ├── sanitize-image-before-snapshot.sh
+│   └── querypie-first-boot.service 설치
+└── ami-validate.sh
 
-```bash
-cd aws/ami
-packer init ami-build.pkr.hcl
+ami-verify.sh
+├── ami-validate.sh
+└── ami-verify.pkr.hcl
+    └── validate-image-runtime.sh
 ```
 
 ## AMI 빌드
 
-### 기본 빌드
+### 입력값
+
+`ami-build.sh`의 인터페이스는 다음과 같습니다.
+
+```text
+./ami-build.sh <querypie_version> [<distro>] [<architecture>]
+```
+
+| 입력 | 기본값 | 현재 제약 |
+|------|--------|-----------|
+| `querypie_version` | 없음 | 필수 |
+| `distro` | `amazon-linux-2023` | `amazon-linux-2023`만 허용 |
+| `architecture` | `x86_64` | `x86_64` 또는 `arm64` |
+| `AMI_REGION` | `ap-northeast-2` | Packer와 AWS API 호출에 동일한 값 전달 |
+| `MODE` | 빈 값 | `release`일 때만 릴리즈 이름 사용 |
+| `PACKER_OPTION` | 빈 값 | 값이 있으면 `packer build`에 그대로 전달 |
+
+현재 QPE 실행 명령은 다음 형태입니다.
 
 ```bash
-cd aws/ami
-./ami-build.sh <querypie_version>
-
-# 예시: QueryPie 11.6.0 빌드
-./ami-build.sh 11.6.0
+AMI_REGION=ap-northeast-2 \
+  ./ami-build.sh <querypie_version> amazon-linux-2023 x86_64
 ```
 
-### 아키텍처 지정 빌드
+`MODE=release`가 아니면 AMI 이름은 `QueryPie-Suite-<version>-<YYYYMMDDHHMM>`입니다.
+`MODE=release`이면 AMI 이름은 `QueryPie-Suite-<version>`입니다.
+
+### 빌드 전 검사
+
+`ami-build.sh`는 Packer 실행 전에 다음 조건을 검사합니다.
+
+1. `packer` 명령이 존재해야 합니다.
+2. `aws` 명령이 존재해야 합니다.
+3. 현재 AWS 자격 증명으로 `sts get-caller-identity`가 성공해야 합니다.
+4. `AMI_REGION`의 `EbsEncryptionByDefault` 값이 정확히 `False`여야 합니다.
+
+EBS 기본 암호화가 활성화되어 있으면 Packer를 실행하지 않습니다.
+
+### Packer 설정
+
+`ami-build.pkr.hcl`의 현재 빌드 설정은 다음과 같습니다.
+
+| 항목 | x86_64 | arm64 |
+|------|--------|-------|
+| 베이스 AMI 소유자 | `amazon` | `amazon` |
+| 베이스 AMI 이름 | `al2023-ami-2023.12.*-kernel-6.12-*` | 동일 |
+| 루트 장치 유형 | `ebs` | `ebs` |
+| 가상화 유형 | `hvm` | `hvm` |
+| 빌드 인스턴스 | Spot `t3.xlarge` | Spot `t4g.xlarge` |
+
+생성되는 AMI는 HVM과 ENA를 사용하고 IMDSv2를 요구합니다.
+루트 볼륨은 `gp3`, 32 GiB, 16,000 IOPS, 1,000 MiB/s로 설정됩니다.
+빌드 인스턴스와 AMI의 루트 볼륨은 암호화하지 않습니다.
+Packer의 임시 보안 그룹은 빌드를 실행한 공인 IP에서 SSH 접속을 허용합니다.
+
+### Packer 실행 순서
+
+`ami-build.pkr.hcl`은 다음 순서로 인스턴스를 구성합니다.
+
+1. `cloud-init status --wait`로 초기화 완료를 기다립니다.
+2. `../scripts/install-docker-on-amazon-linux-2023.sh`를 실행합니다.
+3. `compose/setup.v2.sh`를 `/usr/local/bin/setup.v2.sh`로 설치합니다.
+4. `setup.v2.sh --install-partially-for-ami <querypie_version>`을 실행합니다.
+5. `querypie-first-boot.service`를 설치하고 활성화합니다.
+6. `validate-image-runtime.sh`로 암호화된 장치와 파일시스템이 없는지 검사합니다.
+7. `sanitize-image-before-snapshot.sh`로 빌드 인스턴스 상태를 정리합니다.
+8. AMI 스냅샷과 `manifest.json`을 생성합니다.
+
+부분 설치 단계는 QueryPie 구성 파일을 배치하고 database, querypie, tools 프로파일의 컨테이너 이미지를 미리 받습니다.
+부분 설치 단계는 `.env`의 `AGENT_SECRET`, `KEY_ENCRYPTION_KEY`, `DB_PASSWORD`, `REDIS_PASSWORD` 값을 비운 상태로 AMI를 생성합니다.
+
+### 스냅샷 전 정리
+
+`sanitize-image-before-snapshot.sh`는 다음 변경을 적용합니다.
+
+- SSH 비밀번호 인증과 키보드 대화식 인증을 비활성화합니다.
+- SSH root 로그인을 비활성화하고 root 계정을 잠급니다.
+- `/root`와 `/home` 아래의 `authorized_keys`를 삭제합니다.
+- 기존 SSH host key를 삭제합니다.
+- `cloud-init clean --logs --machine-id`를 실행합니다.
+- systemd random seed를 삭제합니다.
+- DNF 캐시, 임시 파일, 셸 히스토리 및 로그 내용을 정리합니다.
+- 비어 있지 않은 `authorized_keys`가 남아 있으면 빌드를 실패시킵니다.
+
+### 빌드 결과
+
+Packer는 다음 태그를 빌드 인스턴스, AMI 및 스냅샷에 공통으로 설정합니다.
+
+| 태그 | 값 |
+|------|----|
+| `CreatedBy` | `Packer` |
+| `Owner` | `AMI-Builder` |
+| `Purpose` | `Automated QueryPie AMI Build` |
+| `BuildDate` | Packer 타임스탬프 |
+| `Version` | 입력한 QueryPie 버전 |
+
+`manifest.json`의 `custom_data`에는 AMI 이름, QueryPie 버전, 빌드 타임스탬프, 베이스 AMI 이름, 리전 및 아키텍처가 기록됩니다.
+
+Packer가 끝나면 `ami-build.sh`는 현재 계정과 빌드 리전에서 AMI 이름이 같은 가장 최근 이미지를 조회합니다.
+조회한 AMI ID에 대해 `ami-validate.sh`가 성공해야 최종적으로 `Built AMI: <ami-id>`를 출력합니다.
+
+## AMI 구조 검증
+
+`ami-validate.sh`는 EC2 인스턴스를 생성하지 않습니다.
+이 스크립트는 현재 AWS 자격 증명이 소유한 AMI만 `--owners self`로 조회합니다.
 
 ```bash
-# x86_64 (기본값)
-./ami-build.sh 11.6.0 amazon-linux-2023 x86_64
-
-# arm64
-./ami-build.sh 11.6.0 amazon-linux-2023 arm64
+AMI_REGION=ap-northeast-2 \
+  ./ami-validate.sh <ami-id>
 ```
 
-### 릴리즈 모드 빌드
+현재 검사 항목은 다음과 같습니다.
 
-타임스탬프 없이 `QueryPie-Suite-<version>` 이름으로 AMI를 생성합니다.
+| 검사 항목 | 허용 값 |
+|-----------|---------|
+| AMI 상태 | `available` |
+| 루트 장치 유형 | `ebs` |
+| 가상화 유형 | `hvm` |
+| 아키텍처 | `x86_64` 또는 `arm64` |
+| IMDS 지원 | `v2.0` |
+| AMI 설명 | 빈 값이 아님 |
+| EBS 스냅샷 | 하나 이상 존재 |
+| 각 EBS 스냅샷의 `Encrypted` | `False` |
+| EBS 볼륨 크기 합계 | 정수이며 5,120 GiB 이하 |
+
+AMI 조회가 성공한 뒤 발견된 구조 검사 실패는 누적되며, 하나 이상의 실패가 있으면 종료 코드 `1`을 반환합니다.
+AWS CLI 또는 AWS API 호출 자체가 실패하면 해당 시점에 즉시 중단됩니다.
+
+### Marketplace 소스 모드
+
+`--marketplace-source`는 위 구조 검사를 그대로 실행하면서 리전이 `us-east-1`인지 추가로 검사합니다.
 
 ```bash
-MODE=release ./ami-build.sh 11.6.0
+AMI_REGION=us-east-1 \
+  ./ami-validate.sh --marketplace-source <marketplace-ami-id>
 ```
 
-### 빌드 흐름
+이 옵션은 AMI를 판매자 계정으로 공유하거나 복사하지 않습니다.
+판매자 계정 ID와 프로파일은 저장소에 설정되어 있지 않습니다.
+실행 시점의 AWS 자격 증명이 해당 AMI를 소유한 계정이어야 합니다.
+Marketplace 제출, 스캔 실행 및 제품 등록도 이 옵션의 동작 범위에 포함되지 않습니다.
 
-```
-ami-build.sh 실행
-    │
-    ▼
-베이스 AMI 탐색 (al2023-ami-2023.12.*-kernel-6.12-*)
-    │
-    ▼
-Spot Fleet 인스턴스 기동 (t3.xlarge, ~$0.078/시간)
-    │
-    ▼
-cloud-init 완료 대기
-    │
-    ▼
-Docker 설치 (install-docker-on-amazon-linux-2023.sh)
-    │
-    ▼
-setup.v2.sh 설치 (/usr/local/bin/setup.v2.sh)
-    │
-    ▼
-QueryPie 부분 설치 (이미지 Pull, compose.yml 설정)
-setup.v2.sh --install-partially-for-ami <version>
-    │
-    ▼
-querypie-first-boot.service 등록 (최초 부팅 시 설치 완료)
-    │
-    ▼
-최종 정리 (로그, 히스토리, 임시 파일 삭제)
-    │
-    ▼
-AMI 생성 및 태그 부착
-    │
-    ▼
-manifest.json 생성
-```
+## AMI 인스턴스 검증
 
-> 전체 빌드 시간은 약 7~10분입니다.
+`ami-verify.sh`는 다음 순서로 실행됩니다.
 
-## AMI 검증
+1. `packer`와 `aws` 명령이 존재하는지 확인합니다.
+2. `ami-validate.sh`로 AMI 구조를 검사합니다.
+3. AWS API에서 AMI 아키텍처를 조회합니다.
+4. `ami-verify.pkr.hcl`로 해당 AMI의 검증 인스턴스를 기동합니다.
+5. 최초 부팅 설치 완료와 QueryPie 컨테이너 상태를 검사합니다.
+6. `validate-image-runtime.sh`로 암호화된 장치와 파일시스템이 없는지 검사합니다.
 
-빌드된 AMI를 검증합니다. 해당 AMI로 EC2 인스턴스를 기동하여 QueryPie 설치 상태를 확인합니다.
+현재 QPE 실행 명령은 다음 형태입니다.
 
 ```bash
-./ami-verify.sh <AMI_ID>
-
-# 예시
-./ami-verify.sh ami-020ae861e3194f2b7
+AMI_REGION=ap-northeast-2 \
+  ./ami-verify.sh <ami-id>
 ```
 
-> `ami-verify.pkr.hcl`은 `skip_create_ami = true`로 설정되어 있어,
-> 검증용 인스턴스를 기동하고 테스트 후 AMI를 새로 생성하지 않고 종료합니다.
+검증 인스턴스는 AMI 아키텍처에 따라 `t3.xlarge` 또는 `t4g.xlarge`를 사용합니다.
+검증용 루트 볼륨은 임시 `gp3` 32 GiB 볼륨이며 암호화됩니다.
+이 볼륨은 검증 인스턴스에만 연결되고 Marketplace 제출 AMI에는 포함되지 않습니다.
+`skip_create_ami = true`이므로 검증 과정에서 새 AMI를 만들지 않습니다.
 
-## 트러블슈팅
+`setup.v2.sh --verify-installation`은 최초 부팅 완료 marker, systemd 서비스 상태, 컨테이너 엔진, 설치 버전 및 QueryPie 컨테이너 준비 상태를 확인합니다.
+검증이 끝나면 `manifest.json`에는 검증 타임스탬프, 검증용 이름 및 리전이 기록됩니다.
 
-### UnauthorizedOperation: ec2:DescribeImages
+## 최초 부팅 동작
 
-```
-User: arn:aws:iam::142605707876:user/JK is not authorized to perform:
-  ec2:DescribeImages
-```
+빌드 중 설치되는 `querypie-first-boot.service`는 Docker와 네트워크가 준비된 뒤 실행됩니다.
+`/var/lib/querypie/first-boot-done` 파일이 없을 때만 `/usr/local/bin/setup.v2.sh --resume`을 실행합니다.
 
-`PackerAMIBuilder` 정책이 `JK` 유저에 연결되어 있는지 확인합니다.
+`--resume`은 다음 동작을 수행합니다.
 
-```bash
-aws iam list-attached-user-policies --user-name JK
-```
+1. AMI에 부분 설치된 QueryPie 버전을 확인합니다.
+2. `.env` 값을 채웁니다.
+3. database와 tools 컨테이너를 시작합니다.
+4. 데이터베이스 migration을 두 번 실행합니다.
+5. tools 컨테이너를 종료하고 QueryPie 컨테이너를 시작합니다.
+6. 현재 버전 심볼릭 링크를 갱신합니다.
 
-연결되지 않은 경우:
+서비스가 성공하면 `/var/lib/querypie/first-boot-done` marker를 생성합니다.
+서비스 시작 제한 시간은 600초입니다.
 
-```bash
-aws iam attach-user-policy \
-  --user-name JK \
-  --policy-arn arn:aws:iam::142605707876:policy/PackerAMIBuilder
-```
+## 런타임 암호화 검사
 
-### UnauthorizedOperation: ec2:CreateFleet
+`validate-image-runtime.sh`는 빌드 인스턴스와 검증 인스턴스 안에서 실행됩니다.
 
-```
-User: arn:aws:iam::142605707876:user/JK is not authorized to perform:
-  ec2:CreateFleet
-```
+다음 중 하나가 발견되면 종료 코드 `1`을 반환합니다.
 
-`PackerAMIBuilder` 정책이 v3 이상인지 확인합니다.
-v1, v2는 `ec2:CreateFleet`이 누락되어 있습니다.
+- `lsblk` 결과에 `crypt` 장치 유형이 존재
+- `lsblk` 결과에 `crypto_LUKS` 파일시스템이 존재
+- `findmnt` 결과에 `ecryptfs`, `encfs`, `fuse.encfs`, `fuse.gocryptfs`가 존재
 
-```bash
-aws iam get-policy \
-  --policy-arn arn:aws:iam::142605707876:policy/PackerAMIBuilder \
-  --query 'Policy.DefaultVersionId'
-# "v3" 이상이어야 함
-```
+이 검사는 AWS API에서 확인할 수 없는 게스트 OS 내부 암호화 상태만 검사합니다.
+AMI와 EBS 스냅샷의 구조적 속성은 `ami-validate.sh`가 별도로 검사합니다.
 
-### No AMI was found matching filters
+## AMI 목록 조회
 
-```
-Error: Datasource.Execute failed: No AMI was found matching filters
-  name: "al2023-ami-2023.8.*"
+`ami-ls.sh`는 현재 AWS CLI 리전에서 AMI를 조회합니다.
+이 스크립트에는 `AMI_REGION` 처리나 `--region` 인자가 없으므로 프로파일 설정과 환경 변수를 포함한 AWS CLI의 기본 리전 해석 결과를 사용합니다.
+
+```text
+./ami-ls.sh [self|aws-marketplace|redhat|rocky|centos|canonical] [name-prefix]
 ```
 
-`ami-build.pkr.hcl`의 AMI 필터가 오래된 버전을 가리키고 있습니다.
-현재 유효한 필터는 `al2023-ami-2023.12.*-kernel-6.12-*`입니다.
+첫 번째 인자의 기본값은 `self`입니다.
+정해진 별칭이 아닌 값을 전달하면 그 값을 AWS 계정 ID로 사용합니다.
+두 번째 인자는 AMI 이름의 prefix filter로 사용됩니다.
 
-현재 사용 가능한 최신 베이스 AMI를 확인하려면:
+## 현재 자동화 범위 밖
 
-```bash
-# x86_64
-aws ec2 describe-images \
-  --filters "Name=name,Values=al2023-ami-2023.12.*-kernel-6.12-*" \
-            "Name=root-device-type,Values=ebs" \
-            "Name=virtualization-type,Values=hvm" \
-            "Name=architecture,Values=x86_64" \
-  --owners amazon \
-  --region ap-northeast-2 \
-  --query 'sort_by(Images, &CreationDate)[-1].{Name:Name,ImageId:ImageId}'
+다음 작업은 현재 `aws/ami` 스크립트가 수행하지 않습니다.
 
-# arm64
-aws ec2 describe-images \
-  --filters "Name=name,Values=al2023-ami-2023.12.*-kernel-6.12-*" \
-            "Name=root-device-type,Values=ebs" \
-            "Name=virtualization-type,Values=hvm" \
-            "Name=architecture,Values=arm64" \
-  --owners amazon \
-  --region ap-northeast-2 \
-  --query 'sort_by(Images, &CreationDate)[-1].{Name:Name,ImageId:ImageId}'
-```
-
-### 빌드 실패 시 디버깅
-
-`PACKER_OPTION=-on-error=abort`를 사용하면 빌드 실패 시 EC2 인스턴스가 종료되지 않고
-SSH로 접속하여 원인을 분석할 수 있습니다.
-
-```bash
-PACKER_OPTION=-on-error=abort ./ami-build.sh 11.6.0
-```
-
-> 디버깅 후 EC2 인스턴스를 수동으로 종료해야 합니다.
+- AWS CLI 프로파일 또는 Access Key 생성
+- 호출자 계정 ID와 IAM ARN이 QPE 작업 계정과 일치하는지 강제
+- IAM 정책 생성 또는 사용자 연결
+- 판매자 계정 선택과 자격 증명 전환
+- QPE 빌드 계정에서 판매자 계정으로 AMI와 스냅샷 공유
+- 판매자 계정에서 `us-east-1`로 AMI 복사
+- AMI와 스냅샷 태그 재적용
+- AWS Marketplace 제품 생성, 스캔 실행 및 공개 범위 변경


### PR DESCRIPTION
## Stack

이 PR은 AWS Marketplace AMI 작업의 **3/3**입니다.

- [x] [#140 Marketplace 이미지 생성 단계 정비](https://github.com/querypie/tpm/pull/140) — `main`에 병합됨
- [x] [#142 빌드 리전과 아키텍처 전달](https://github.com/querypie/tpm/pull/142) — `main`에 병합됨
- [x] [#143 제출 전 AMI 구조 검증](https://github.com/querypie/tpm/pull/143) — `main`에 병합됨
- [ ] **[#144 현재 빌드 동작과 검증 경계 문서화](https://github.com/querypie/tpm/pull/144) — 현재 PR**

남은 병합 대상은 #144입니다.

## 기존 문제

README에 실제 스크립트 동작과 범용 AWS Marketplace 운영 가이드가 섞여 있었습니다.
저장소가 생성하거나 강제하지 않는 IAM 정책, AWS CLI 프로파일, 판매자 계정, AMI 공유·복사, Marketplace 등록 절차도 현재 설정처럼 기술되어 있었습니다.
빌드 과정에는 실제 Packer 템플릿에 없는 OS 보안 업데이트 단계도 포함되어 있었습니다.

## 변경 내용

- QPE 계정 `142605707876`, IAM 사용자 `JK`, 기본 리전 `ap-northeast-2`를 현재 실행 컨텍스트로 정리했습니다.
- AWS CLI 프로파일은 저장소에 설정되어 있지 않으며, 스크립트는 실행 시점의 AWS 자격 증명 체인을 사용한다는 경계를 명시했습니다.
- 사용자가 실행하는 네 개의 명령과 Packer·runtime validation·sanitize·first boot 파일의 호출 관계를 문서화했습니다.
- `ami-build.sh`의 입력값, AMI 이름 규칙, 빌드 전 검사, 실제 Packer 설정과 provisioning 순서를 코드 기준으로 기술했습니다.
- `ami-validate.sh`, `ami-verify.sh`, `validate-image-runtime.sh`의 검사 범위와 실패 방식을 분리했습니다.
- `--marketplace-source`가 일반 빌드 리전을 제한하지 않고 `us-east-1` 제출 후보에만 추가 검사를 적용한다는 점을 명확히 했습니다.
- IAM 정책 작성법, 도구 설치법, 판매자 등록, 계정 간 공유·복사 명령, Marketplace UI 절차와 일반 트러블슈팅을 제거했습니다.
- 이 디렉토리가 자동화하지 않는 작업을 별도 목록으로 명시했습니다.

## 리뷰 범위

- Base: `main` (`af87b47`, #143 병합 결과)
- Head: `codex/marketplace-ami-promotion-docs`
- 고유 변경: 커밋 1개, `aws/ami/README.md` 1파일
- #140, #142, #143의 변경은 이 PR diff에 포함하지 않습니다.

## 검증

- Bash syntax 및 ShellCheck 통과
- Bats 9/9 통과
- 두 Packer 템플릿의 `validate -syntax-only` 통과
- Markdown 코드 펜스, 구현 상수 및 제거 대상 문구 assertion 통과
- `git diff --check` 통과
- `packer fmt -check`는 `main`에 이미 존재하는 HCL 정렬 차이를 보고하며, 이 PR에는 HCL 변경이 없습니다.

JK 사용자의 실제 AWS 자격 증명, AMI 빌드, 계정 간 공유·복사 및 AWS Marketplace 제출은 수행하지 않았습니다.
