### PR TITLE
fix(aws/ami): AMI 연결을 direct SSH로 복원

### DIFF
--- a/aws/ami/README.md
+++ b/aws/ami/README.md
@@ -29,8 +29,10 @@ export AMI_REGION=ap-northeast-2
 스크립트는 응답의 계정 ID나 IAM ARN이 위 표의 값과 일치하는지 검사하지 않습니다.
 `ami-verify.sh`, `ami-validate.sh`, `ami-ls.sh`도 계정이나 프로파일을 내부에서 변경하지 않습니다.
 
-AMI 빌드와 인스턴스 검증에는 `packer`, `aws`, `session-manager-plugin` 명령이 필요합니다.
-Packer는 Session Manager 플러그인을 사용해 빌드 및 검증 인스턴스에 대한 SSH 터널을 생성합니다.
+AMI 빌드와 인스턴스 검증에는 `packer`와 `aws` 명령이 필요합니다.
+Packer는 빌드 및 검증 인스턴스의 공인 IP에 직접 SSH로 연결합니다.
+실행 호스트는 외부 TCP 22번 연결을 허용해야 하며, 빌드 중 공인 IP가 변경되지 않아야 합니다.
+VPN이나 네트워크 정책이 이 연결을 차단하는 환경에서는 direct SSH가 가능한 별도 실행 환경을 사용해야 합니다.
 
 ## 파일과 호출 관계
 
@@ -104,9 +106,8 @@ AMI_REGION=ap-northeast-2 \
 
 1. `packer` 명령이 존재해야 합니다.
 2. `aws` 명령이 존재해야 합니다.
-3. `session-manager-plugin` 명령이 존재해야 합니다.
-4. 현재 AWS 자격 증명으로 `sts get-caller-identity`가 성공해야 합니다.
-5. `AMI_REGION`의 `EbsEncryptionByDefault` 값이 정확히 `False`여야 합니다.
+3. 현재 AWS 자격 증명으로 `sts get-caller-identity`가 성공해야 합니다.
+4. `AMI_REGION`의 `EbsEncryptionByDefault` 값이 정확히 `False`여야 합니다.
 
 EBS 기본 암호화가 활성화되어 있으면 Packer를 실행하지 않습니다.
 
@@ -125,7 +126,8 @@ EBS 기본 암호화가 활성화되어 있으면 Packer를 실행하지 않습�
 생성되는 AMI는 HVM과 ENA를 사용하고 IMDSv2를 요구합니다.
 루트 볼륨은 `gp3`, 32 GiB, 16,000 IOPS, 1,000 MiB/s로 설정됩니다.
 빌드 인스턴스와 AMI의 루트 볼륨은 암호화하지 않습니다.
-Packer는 `ec2-session-manager` 인스턴스 프로파일과 Session Manager를 통해 SSH를 연결합니다.
+Packer는 기본 public subnet의 빌드 인스턴스에 공인 IP를 할당하고 직접 SSH로 연결합니다.
+임시 보안 그룹은 Packer 실행 호스트의 공인 IP에서 들어오는 SSH만 허용합니다.
 
 ### Packer 실행 순서
 
@@ -221,7 +223,7 @@ Marketplace 제출, 스캔 실행 및 제품 등록도 이 옵션의 동작 범�
 
 `ami-verify.sh`는 다음 순서로 실행됩니다.
 
-1. `packer`, `aws`, `session-manager-plugin` 명령이 존재하는지 확인합니다.
+1. `packer`와 `aws` 명령이 존재하는지 확인합니다.
 2. `ami-validate.sh`로 AMI 구조를 검사합니다.
 3. AWS API에서 AMI 아키텍처를 조회합니다.
 4. `ami-verify.pkr.hcl`로 해당 AMI의 검증 인스턴스를 기동합니다.

--- a/aws/ami/ami-build.pkr.hcl
+++ b/aws/ami/ami-build.pkr.hcl
@@ -125,8 +125,7 @@ source "amazon-ebs" "amazon-linux-2023" {
 
   region       = var.region
   ssh_username = local.ssh_username
-  ssh_interface        = "session_manager"
-  iam_instance_profile = "ec2-session-manager"
+  ssh_interface = "public_ip"
   associate_public_ip_address = true
   # ssh_private_key_file = "demo-targets.pem"
   # ssh_keypair_name = "demo-targets"
@@ -161,6 +160,9 @@ source "amazon-ebs" "amazon-linux-2023" {
     http_tokens                 = "required"
     http_put_response_hop_limit = 1
   }
+
+  # Security group configuration
+  temporary_security_group_source_public_ip = true
 
   # Tags of the EC2 instance used for building the AMI
   run_tags = local.instance_tags

--- a/aws/ami/ami-build.sh
+++ b/aws/ami/ami-build.sh
@@ -66,11 +66,6 @@ function validate_environment() {
     exit 1
   fi
 
-  if ! command -v session-manager-plugin &>/dev/null; then
-    log::error "AWS Session Manager plugin is not installed. Please install session-manager-plugin to continue."
-    exit 1
-  fi
-
   log::do aws sts get-caller-identity --output text >/dev/null
 
   local encryption_by_default

--- a/aws/ami/ami-verify.pkr.hcl
+++ b/aws/ami/ami-verify.pkr.hcl
@@ -68,9 +68,8 @@ source "amazon-ebs" "ami-verify" {
   region        = var.region
   instance_type = local.instance_type
   ssh_username  = local.ssh_username
-  ssh_interface = "session_manager"
+  ssh_interface = "public_ip"
 
-  iam_instance_profile        = "ec2-session-manager"
   associate_public_ip_address = true
 
   subnet_filter {
@@ -102,6 +101,9 @@ source "amazon-ebs" "ami-verify" {
     http_tokens                 = "required"
     http_put_response_hop_limit = 1
   }
+
+  # Security group configuration
+  temporary_security_group_source_public_ip = true
 
   # Tags of the EC2 instance used for building the AMI
   run_tags = local.instance_tags

--- a/aws/ami/ami-verify.sh
+++ b/aws/ami/ami-verify.sh
@@ -51,11 +51,6 @@ function validate_environment() {
     log::error "AWS CLI is not installed. Please install AWS CLI to continue."
     exit 1
   fi
-
-  if ! command -v session-manager-plugin &>/dev/null; then
-    log::error "AWS Session Manager plugin is not installed. Please install session-manager-plugin to continue."
-    exit 1
-  fi
 }
 
 function main() {

--- a/aws/ami/tests/ami-build-region.bats
+++ b/aws/ami/tests/ami-build-region.bats
@@ -40,12 +40,6 @@ printf '%s\n' "$*" >>"$PACKER_INVOCATIONS_FILE"
 EOF
   chmod +x "$MOCK_BIN/packer"
 
-  cat >"$MOCK_BIN/session-manager-plugin" <<'EOF'
-#!/usr/bin/env bash
-exit 0
-EOF
-  chmod +x "$MOCK_BIN/session-manager-plugin"
-
   PACKER_INVOCATIONS_FILE="$TEST_ROOT/packer-invocations"
   export PACKER_INVOCATIONS_FILE
   : >"$PACKER_INVOCATIONS_FILE"
@@ -76,32 +70,6 @@ teardown() {
 
   [ "$status" -eq 1 ]
   [[ "$output" == *"EBS encryption by default must be disabled"* ]]
-  [ ! -s "$PACKER_INVOCATIONS_FILE" ]
-}
-
-@test "AMI build stops before Packer when Session Manager plugin is missing" {
-  rm "$MOCK_BIN/session-manager-plugin"
-
-  run env \
-    PATH="$MOCK_BIN:/usr/bin:/bin" \
-    AMI_REGION=ap-northeast-2 \
-    "$BATS_TEST_DIRNAME/../ami-build.sh" 11.6.0 amazon-linux-2023 x86_64
-
-  [ "$status" -eq 1 ]
-  [[ "$output" == *"AWS Session Manager plugin is not installed"* ]]
-  [ ! -s "$PACKER_INVOCATIONS_FILE" ]
-}
-
-@test "AMI verification stops before Packer when Session Manager plugin is missing" {
-  rm "$MOCK_BIN/session-manager-plugin"
-
-  run env \
-    PATH="$MOCK_BIN:/usr/bin:/bin" \
-    AMI_REGION=ap-northeast-2 \
-    "$BATS_TEST_DIRNAME/../ami-verify.sh" ami-0123456789abcdef0
-
-  [ "$status" -eq 1 ]
-  [[ "$output" == *"AWS Session Manager plugin is not installed"* ]]
   [ ! -s "$PACKER_INVOCATIONS_FILE" ]
 }
 
@@ -145,36 +113,36 @@ teardown() {
   [ "$status" -eq 0 ]
 }
 
-@test "AMI template tunnels SSH through Session Manager" {
+@test "AMI template connects over direct public SSH" {
   run grep -E \
-    'ssh_interface[[:space:]]*=[[:space:]]*"session_manager"' \
-    "$BATS_TEST_DIRNAME/../ami-build.pkr.hcl"
-  [ "$status" -eq 0 ]
-
-  run grep -E \
-    'iam_instance_profile[[:space:]]*=[[:space:]]*"ec2-session-manager"' \
+    'ssh_interface[[:space:]]*=[[:space:]]*"public_ip"' \
     "$BATS_TEST_DIRNAME/../ami-build.pkr.hcl"
   [ "$status" -eq 0 ]
 
   run grep -F \
-    'temporary_security_group_source_public_ip' \
+    'temporary_security_group_source_public_ip = true' \
+    "$BATS_TEST_DIRNAME/../ami-build.pkr.hcl"
+  [ "$status" -eq 0 ]
+
+  run grep -E \
+    'session_manager|ec2-session-manager' \
     "$BATS_TEST_DIRNAME/../ami-build.pkr.hcl"
   [ "$status" -eq 1 ]
 }
 
-@test "AMI verification tunnels SSH through Session Manager" {
+@test "AMI verification connects over direct public SSH" {
   run grep -E \
-    'ssh_interface[[:space:]]*=[[:space:]]*"session_manager"' \
-    "$BATS_TEST_DIRNAME/../ami-verify.pkr.hcl"
-  [ "$status" -eq 0 ]
-
-  run grep -E \
-    'iam_instance_profile[[:space:]]*=[[:space:]]*"ec2-session-manager"' \
+    'ssh_interface[[:space:]]*=[[:space:]]*"public_ip"' \
     "$BATS_TEST_DIRNAME/../ami-verify.pkr.hcl"
   [ "$status" -eq 0 ]
 
   run grep -F \
-    'temporary_security_group_source_public_ip' \
+    'temporary_security_group_source_public_ip = true' \
+    "$BATS_TEST_DIRNAME/../ami-verify.pkr.hcl"
+  [ "$status" -eq 0 ]
+
+  run grep -E \
+    'session_manager|ec2-session-manager' \
     "$BATS_TEST_DIRNAME/../ami-verify.pkr.hcl"
   [ "$status" -eq 1 ]
 }


### PR DESCRIPTION
## 문제 현상

PR #145에서 특정 실행 환경의 outbound TCP/22 제한을 해결하기 위해 AMI build/verify 연결을 Session Manager로 전환했습니다. 그러나 이 제약은 공유 Packer 스크립트의 요구사항이 아니며, 전환 이후 Amazon Packer 플러그인의 로컬 SSM 포트포워딩 프로세스가 종료된 인스턴스를 계속 기다려 빌드가 정상 종료되지 않는 현상이 발생했습니다.

## 구현 내용

- AMI build/verify의 연결 방식을 공인 IP를 이용한 direct SSH로 복원했습니다.
- `ec2-session-manager` instance profile과 `session-manager-plugin` 사전 검사를 제거했습니다.
- public subnet과 공인 IP 할당은 유지했습니다.
- Packer 실행 호스트의 공인 IP만 TCP/22로 허용하도록 임시 보안 그룹 설정을 복원했습니다.
- README와 Bats 테스트를 direct SSH 계약에 맞게 정리했습니다.
- Docker group 반영을 위한 기존 `expect_disconnect` 및 `killall sshd sshd-session` 흐름은 유지했습니다.
- PR #145에 포함된 Spot fallback, Compose 설치, listener port 예약, machine-id 정리 등 SSM과 무관한 필수 수정은 유지했습니다.

## 검증 결과

- `bats aws/ami/tests`: 20/20 통과
- 변경 shell script의 `bash -n`, ShellCheck 통과
- Packer validation 통과:
  - AMI build: x86_64, arm64
  - AMI verify: x86_64, arm64
  - install 검증: x86_64, arm64
  - upgrade/uninstall 검증: x86_64, arm64
- x86_64 실빌드 시 direct public SSH, public subnet, 실행 호스트 IP의 `/32` SSH ingress가 적용되는 것을 확인했습니다.
- 다만 현재 VPN 환경에서는 EC2 공인 IP의 TCP/22가 차단되어 SSH 연결 대기에서 종료됐습니다. 이때 Packer가 builder instance, launch template, 임시 key pair와 security group을 모두 자동 정리했으며 AMI artifact는 생성되지 않았습니다.
- 따라서 전체 AMI 생성·부팅 검증은 outbound TCP/22가 가능한 실행 환경에서 후속 수행이 필요합니다.

## 영향

- AMI 빌드 환경에서 Session Manager plugin과 전용 IAM instance profile이 더 이상 필요하지 않습니다.
- 실행 호스트는 EC2 공인 IP로 outbound TCP/22 연결이 가능해야 하고, 빌드 중 공인 IP가 유지되어야 합니다.
- SSM 포트포워딩 종료 교착을 우회하기 위한 별도 플러그인 패치 없이 기존 Packer direct SSH 절차로 복귀합니다.

## 관련

- PR #145의 SSM 전환 부분만 되돌립니다.