### PR TITLE
docs: ACP Community·Standard Marketplace 최종 등록 계획

### DIFF
--- a/aws/marketplace/FIELD-CATALOG.md
+++ b/aws/marketplace/FIELD-CATALOG.md
@@ -14,7 +14,7 @@ AWS 판매자 가이드와 Catalog API의 한도가 다른 경우, 판매자 포
 | 입력 항목 | 필수 여부 | 적용 기준 | 파일 |
 |-----------|-----------|-----------|------|
 | Product title | 필수 | ASCII, 최대 72자, 상품과 에디션을 이름만으로 식별 | `01-product-title.md` |
-| SKU | 선택 | 최대 100자, 구매자에게 비노출 | `02-sku.md` |
+| SKU | 선택 | 최대 100자, 상품 단위 내부 참조값이며 가격 dimension과 분리 | `02-sku.md` |
 | Short description | 필수 | API 최대 1,000자, 본 초안은 작성 가이드의 350자 이내 적용 | `03-short-description.md` |
 | Long description | 필수 | 최대 5,000자, 기능·효익·사용 방식·구체 정보 포함 | `04-long-description.md` |
 | Product logo image URL | 필수 | 공개 S3 HTTPS URL, 투명 또는 흰 배경, 120~640px, 1:1 또는 2:1 | `05-product-logo.md` |

--- a/aws/marketplace/README.md
+++ b/aws/marketplace/README.md
@@ -12,14 +12,15 @@
 각 상품은 별도의 AWS Marketplace 상품 ID와 상품 코드를 가져야 합니다.
 Community, Standard, Enterprise가 같은 컨테이너 이미지를 사용하더라도 에디션별 가격, 라이선스 권리, 지원 조건이 다르므로 별도 상품으로 관리합니다.
 
-| 상품 | 제안 가격 모델 | 상태 |
-|------|----------------|------|
-| QueryPie ACP Community Edition | Free | 라이선스 자동화 선행 필요 |
-| QueryPie ACP Standard Edition | AMI with contract pricing | 10/15/20 users tier와 12개월 선불 가격 확정, 권리 연동 필요 |
-| QueryPie ACP Enterprise Edition | AMI with contract pricing 및 private offer | 계약 차원, 지원 범위, 공개 가격 정책 확정 필요 |
+| 상품 | SKU | 가격 모델 | 상태 |
+|------|-----|-----------|------|
+| QueryPie ACP Community Edition | `QP1201E-CDS-AWS` | Free | 라이선스 자동화 선행 필요 |
+| QueryPie ACP Standard Edition | `QP1201E-SDS-AWS` | AMI with contract pricing | 10/15/20 users tier와 12개월 선불 가격 확정, 권리 연동 필요 |
+| QueryPie ACP Enterprise Edition | 미확정 | AMI with contract pricing 및 private offer | 계약 차원, 지원 범위, 공개 가격 정책 확정 필요 |
 
 가격 모델 선택 근거와 대안은 [SUBMISSION-FIELDS.md](SUBMISSION-FIELDS.md)에 정리했습니다.
 Standard Edition의 계약 차원과 구매·실행 흐름은 [products/standard/12-contract-pricing.md](products/standard/12-contract-pricing.md)에 정리했습니다.
+Community Edition과 Standard Edition의 최종 등록 순서는 [REGISTRATION-PLAN.md](REGISTRATION-PLAN.md)에 정리했습니다.
 
 ## 상품별 입력 파일
 
@@ -40,6 +41,8 @@ products/<edition>/
 └── 11-support-information.md
 ```
 
+Standard의 계약 가격은 `products/standard/12-contract-pricing.md`에서 별도로 관리합니다.
+
 영어 섹션은 실제 Marketplace 제출 원문입니다.
 한국어 섹션은 한국어 사용 개발자가 영어 원문을 검토하기 위한 번역입니다.
 지원 이메일은 `support@querypie.com`이고 기술지원 정보 웹사이트는 `https://docs.querypie.com/support`입니다.
@@ -51,13 +54,14 @@ products/<edition>/
 - [FIELD-CATALOG.md](FIELD-CATALOG.md): 필수 입력 항목, 제한, 파일 위치
 - [LOCALIZATION.md](LOCALIZATION.md): 영어 원문과 AWS 기본 자동 번역 운영 방식
 - [SUBMISSION-FIELDS.md](SUBMISSION-FIELDS.md): 버전, AMI, 배포, 가격, EULA, 국가와 리전 입력값
+- [REGISTRATION-PLAN.md](REGISTRATION-PLAN.md): Community와 Standard의 최종 상품 등록 계획
 - [RELEASE-READINESS.md](RELEASE-READINESS.md): 현재 구현에서 등록 전에 해결해야 할 이슈
 - [SOURCES.md](SOURCES.md): AWS와 QueryPie 공식 근거 자료
 
 ## 사용 순서
 
 1. [RELEASE-READINESS.md](RELEASE-READINESS.md)의 차단 항목을 해결합니다.
-2. [SUBMISSION-FIELDS.md](SUBMISSION-FIELDS.md)의 미확정 값을 결정합니다.
+2. [REGISTRATION-PLAN.md](REGISTRATION-PLAN.md)의 상품, SKU, 버전, 가격 차원을 기준으로 등록합니다.
 3. 상품별 입력 파일의 영어 문안을 AWS Partner Central에 입력합니다.
 4. 상품을 Limited 상태로 만든 뒤 영어 원문과 AWS 자동 번역이 정상적으로 노출되는지 확인합니다.
 5. AMI 스캔과 실제 구매·실행 테스트를 마친 뒤 Public 전환을 요청합니다.

--- a/aws/marketplace/README.md
+++ b/aws/marketplace/README.md
@@ -15,7 +15,7 @@ Community, Standard, Enterprise가 같은 컨테이너 이미지를 사용하더
 | 상품 | 제안 가격 모델 | 상태 |
 |------|----------------|------|
 | QueryPie ACP Community Edition | Free | 라이선스 자동화 선행 필요 |
-| QueryPie ACP Standard Edition | AMI with contract pricing | 10/15/20 users tier 확정, 12개월 가격과 권리 연동 필요 |
+| QueryPie ACP Standard Edition | AMI with contract pricing | 10/15/20 users tier와 12개월 선불 가격 확정, 권리 연동 필요 |
 | QueryPie ACP Enterprise Edition | AMI with contract pricing 및 private offer | 계약 차원, 지원 범위, 공개 가격 정책 확정 필요 |
 
 가격 모델 선택 근거와 대안은 [SUBMISSION-FIELDS.md](SUBMISSION-FIELDS.md)에 정리했습니다.

--- a/aws/marketplace/README.md
+++ b/aws/marketplace/README.md
@@ -15,10 +15,11 @@ Community, Standard, Enterprise가 같은 컨테이너 이미지를 사용하더
 | 상품 | 제안 가격 모델 | 상태 |
 |------|----------------|------|
 | QueryPie ACP Community Edition | Free | 라이선스 자동화 선행 필요 |
-| QueryPie ACP Standard Edition | AMI with contract pricing | 가격 차원과 권리 연동 확정 필요 |
+| QueryPie ACP Standard Edition | AMI with contract pricing | 10/15/20 users tier 확정, 12개월 가격과 권리 연동 필요 |
 | QueryPie ACP Enterprise Edition | AMI with contract pricing 및 private offer | 계약 차원, 지원 범위, 공개 가격 정책 확정 필요 |
 
 가격 모델 선택 근거와 대안은 [SUBMISSION-FIELDS.md](SUBMISSION-FIELDS.md)에 정리했습니다.
+Standard Edition의 계약 차원과 구매·실행 흐름은 [products/standard/12-contract-pricing.md](products/standard/12-contract-pricing.md)에 정리했습니다.
 
 ## 상품별 입력 파일
 

--- a/aws/marketplace/REGISTRATION-PLAN.md
+++ b/aws/marketplace/REGISTRATION-PLAN.md
@@ -56,7 +56,7 @@ VAT, GST, 판매세와 AWS 인프라 요금은 소프트웨어 가격과 별도�
 ## 라이선스 적용
 
 Community는 추가 신청 폼, 이메일 입력 또는 별도 라이선스 파일 없이 최대 5명의 권리를 자동 활성화해야 합니다.
-Standard는 AWS License Manager의 `CheckoutLicense` 응답에서 구매한 dimension을 확인합니다.
+Standard는 AWS License Manager의 tiered license model에 따라 가능한 세 dimension을 `CheckoutLicense`에 전달하고, 응답에 반환된 구매 dimension 하나를 확인합니다.
 
 | Entitlement | 활성 사용자 상한 |
 |-------------|------------------|
@@ -64,7 +64,7 @@ Standard는 AWS License Manager의 `CheckoutLicense` 응답에서 구매한 dime
 | `Standard15Users` | 15 |
 | `Standard20Users` | 20 |
 
-Standard entitlement가 없거나 만료되면 10 users를 기본으로 부여하지 않습니다.
+Standard entitlement가 없거나, 둘 이상이거나, 알 수 없는 이름이거나, 만료되면 10 users를 기본으로 부여하지 않습니다.
 이 경우 Standard Edition 활성화를 차단하고 구매 또는 갱신 안내를 제공합니다.
 
 Contract 라이선스는 특정 EC2 인스턴스에 고정되지 않습니다.

--- a/aws/marketplace/REGISTRATION-PLAN.md
+++ b/aws/marketplace/REGISTRATION-PLAN.md
@@ -1,0 +1,116 @@
+# QueryPie ACP AWS Marketplace 최종 등록 계획
+
+## 범위
+
+이 계획은 QueryPie ACP Community Edition과 QueryPie ACP Standard Edition을 각각 Public Single AMI 상품으로 등록하는 절차를 정의합니다.
+Seller 등록과 Enterprise Edition은 이 계획의 범위에 포함하지 않습니다.
+
+## 최종 상품 구조
+
+Community와 Standard는 가격, 권리, 지원 조건이 다르므로 별도 AWS Marketplace 상품으로 등록합니다.
+각 상품은 자체 Product ID, Product code, SKU와 Public Offer를 가집니다.
+상품 SKU와 기본 사용자 수는 [QueryPie ACP 가격 정책 - 2026 최신](https://querypie.atlassian.net/wiki/spaces/QPBusiness/pages/2311061525/QueryPie+ACP+-+2026)을 기준으로 합니다.
+
+| 상품 | Product SKU | 가격 모델 | 사용자 권리 |
+|------|-------------|-----------|-------------|
+| QueryPie ACP Community Edition | `QP1201E-CDS-AWS` | Free | 최대 5 active users |
+| QueryPie ACP Standard Edition | `QP1201E-SDS-AWS` | AMI with contract pricing | 구매한 10/15/20 users tier |
+
+## Standard 가격 dimension
+
+Standard는 Product SKU 하나를 유지하고 사용자 수를 tiered Contract pricing dimension으로 구분합니다.
+구매자는 다음 세 dimension 중 하나만 선택합니다.
+
+| Dimension API name | 구매자 표시명 | 12개월 선불 가격 | 적용 권리 |
+|--------------------|---------------|-----------------|-----------|
+| `Standard10Users` | `Standard 10 Users` | `6000.000 USD` | 최대 10 active users |
+| `Standard15Users` | `Standard 15 Users` | `9000.000 USD` | 최대 15 active users |
+| `Standard20Users` | `Standard 20 Users` | `12000.000 USD` | 최대 20 active users |
+
+가격 기준은 사용자 1명당 연간 `USD 600`입니다.
+VAT, GST, 판매세와 AWS 인프라 요금은 소프트웨어 가격과 별도입니다.
+간접세는 별도 dimension으로 등록하지 않고 AWS Marketplace의 국가별 세금 처리에 따릅니다.
+
+다음 코드는 AWS Marketplace SKU로 등록하지 않습니다.
+
+- `QP1201E-SDS-AWS10`
+- `QP1201E-SDS-AWS15`
+- `QP1201E-SDS-AWS20`
+- `QP1201E-SAS-AWS`
+
+필요한 경우에만 사내 ERP에서 추가 사용자를 분해하는 내부 관리 코드로 사용합니다.
+
+## 버전 등록
+
+각 상품에 동일한 두 소프트웨어 버전을 등록합니다.
+
+| 등록 순서 | Version title | 상태 기준 |
+|-----------|---------------|-----------|
+| 1 | `11.5.7` | 판매자 계정 `us-east-1` AMI와 스캔 결과 확인 |
+| 2 | `11.6.4` | 판매자 계정 `us-east-1` AMI를 준비한 뒤 스캔 |
+
+버전은 에디션이나 사용자 tier를 구분하는 용도로 사용하지 않습니다.
+각 Version title은 상품 안에서 고유해야 하며 해당 버전의 AMI와 변경할 수 없게 연결됩니다.
+`11.6.4` AMI가 준비되지 않았다면 해당 버전은 생성하거나 Public 제출하지 않습니다.
+
+## 라이선스 적용
+
+Community는 추가 신청 폼, 이메일 입력 또는 별도 라이선스 파일 없이 최대 5명의 권리를 자동 활성화해야 합니다.
+Standard는 AWS License Manager의 `CheckoutLicense` 응답에서 구매한 dimension을 확인합니다.
+
+| Entitlement | 활성 사용자 상한 |
+|-------------|------------------|
+| `Standard10Users` | 10 |
+| `Standard15Users` | 15 |
+| `Standard20Users` | 20 |
+
+Standard entitlement가 없거나 만료되면 10 users를 기본으로 부여하지 않습니다.
+이 경우 Standard Edition 활성화를 차단하고 구매 또는 갱신 안내를 제공합니다.
+
+Contract 라이선스는 특정 EC2 인스턴스에 고정되지 않습니다.
+여러 인스턴스를 허용할 경우 사용자 상한을 설치별로 적용할지 구매 AWS 계정 전체로 적용할지 출시 전에 확정해야 합니다.
+
+## AMI 준비
+
+각 제출 AMI는 다음 조건을 충족해야 합니다.
+
+- 판매자 계정의 `us-east-1`에 존재합니다.
+- EBS snapshot과 파일시스템은 암호화되지 않습니다.
+- HVM, EBS-backed, x86-64 또는 64-bit ARM 아키텍처를 사용합니다.
+- AMI Name과 Description에 정확한 상품명, 에디션, 버전, OS를 기록합니다.
+- 고정 비밀번호, 자격 증명, SSH authorized key를 포함하지 않습니다.
+- `Test Add Version` 스캔을 문제없이 통과합니다.
+
+에디션별 권리와 Product code를 명확히 적용할 수 있도록 Community와 Standard 제출 AMI를 별도 자산으로 관리합니다.
+
+## 등록 순서
+
+1. Community와 Standard의 상품 메타데이터, SKU, EULA, 지원 정보와 국가 범위를 입력합니다.
+2. 각 상품의 첫 버전과 AMI deployment 정보를 입력하여 Limited 상품을 생성합니다.
+3. Standard에 tiered Contract pricing과 12개월 가격을 입력합니다.
+4. 내부 구매 계정을 allowlist에 추가합니다.
+5. 각 AMI에 대해 `Test Add Version`과 보안 스캔을 완료합니다.
+6. Community 무료 활성화와 Standard의 세 tier 구매를 각각 검증합니다.
+7. 구매 후 버전과 리전을 선택하고 EC2 인스턴스를 생성합니다.
+8. QueryPie가 구매한 사용자 권리를 적용하는지 확인합니다.
+9. 두 번째 소프트웨어 버전을 추가하고 동일한 실행 검증을 반복합니다.
+10. 상품별로 Public 전환 요청을 제출합니다.
+
+## Public 제출 전 완료 조건
+
+- Community가 개인정보나 외부 라이선스 신청 없이 활성화됩니다.
+- Standard의 10/15/20 users tier가 하나의 Product SKU 아래에 표시됩니다.
+- 세 tier가 각각 `6000`, `9000`, `12000 USD`로 선불 청구됩니다.
+- License Manager entitlement와 QueryPie 사용자 상한이 일치합니다.
+- entitlement가 없거나 만료된 Standard 인스턴스가 활성화되지 않습니다.
+- `11.5.7`과 `11.6.4`의 AMI 소유권, 이름, Description과 스캔 결과를 확인했습니다.
+- 구매자가 Marketplace 구독 후 EC2 VM을 정상 생성하고 최초 관리자 설정을 완료할 수 있습니다.
+- 환불 정책, 관련 세금, AWS 인프라 비용과 지원 범위가 상품 설명에 표시됩니다.
+
+## 남은 결정
+
+- Standard 다중 EC2 인스턴스의 사용자 상한을 설치별 또는 구매 계정 전체 중 하나로 확정합니다.
+- Public 구매 허용 국가와 환불 조건을 확정합니다.
+- `11.6.4` 제출 AMI의 실제 준비 상태를 확인합니다.
+
+위 항목이 해결되기 전에는 Public 전환 요청을 제출하지 않습니다.

--- a/aws/marketplace/RELEASE-READINESS.md
+++ b/aws/marketplace/RELEASE-READINESS.md
@@ -13,7 +13,7 @@
 AWS는 Free 또는 Paid AMI 상품이 추가 라이선스를 요구하지 않고, 구매자가 상품 사용을 위해 이메일 같은 개인정보를 제공하지 않아도 되어야 한다고 명시합니다.
 
 Marketplace 상품 코드 또는 AWS entitlement를 인식해 Community 권리를 자동 활성화해야 합니다.
-Standard는 `Standard10Users`, `Standard15Users`, `Standard20Users` 중 구매한 tier를 License Manager에서 확인하고 각각 10명, 15명, 20명의 활성 사용자 상한을 자동 적용해야 합니다.
+Standard는 `Standard10Users`, `Standard15Users`, `Standard20Users`를 License Manager에 checkout 요청하고, 응답에 반환된 구매 tier 하나에 따라 각각 10명, 15명, 20명의 활성 사용자 상한을 자동 적용해야 합니다.
 Enterprise를 AWS 과금 상품으로 판매하려면 별도의 계약 entitlement를 라이선스 용량과 자동 연동해야 합니다.
 외부에서 라이선스를 구매하는 현재 흐름을 유지하려면 BYOL을 선택해야 하지만 AWS Marketplace 소프트웨어 과금은 사용할 수 없습니다.
 

--- a/aws/marketplace/RELEASE-READINESS.md
+++ b/aws/marketplace/RELEASE-READINESS.md
@@ -13,7 +13,8 @@
 AWS는 Free 또는 Paid AMI 상품이 추가 라이선스를 요구하지 않고, 구매자가 상품 사용을 위해 이메일 같은 개인정보를 제공하지 않아도 되어야 한다고 명시합니다.
 
 Marketplace 상품 코드 또는 AWS entitlement를 인식해 Community 권리를 자동 활성화해야 합니다.
-Standard와 Enterprise를 AWS 과금 상품으로 판매하려면 계약 entitlement를 라이선스 용량과 자동 연동해야 합니다.
+Standard는 `Standard10Users`, `Standard15Users`, `Standard20Users` 중 구매한 tier를 License Manager에서 확인하고 각각 10명, 15명, 20명의 활성 사용자 상한을 자동 적용해야 합니다.
+Enterprise를 AWS 과금 상품으로 판매하려면 별도의 계약 entitlement를 라이선스 용량과 자동 연동해야 합니다.
 외부에서 라이선스를 구매하는 현재 흐름을 유지하려면 BYOL을 선택해야 하지만 AWS Marketplace 소프트웨어 과금은 사용할 수 없습니다.
 
 ### 고정 초기 관리자 비밀번호
@@ -29,6 +30,10 @@ AMI 최초 부팅 시 임의 비밀번호를 생성하고 안전하게 조회하
 세 상품이 같은 애플리케이션 이미지를 사용하더라도 AWS Marketplace에서는 서로 다른 상품 코드와 오퍼를 가집니다.
 런타임이 EC2 instance identity document의 Marketplace product code와 entitlement를 검증해 Community, Standard, Enterprise 권리를 정확히 적용해야 합니다.
 현재 저장소에는 이 연동이 보이지 않으므로 구현과 통합 테스트가 필요합니다.
+
+Standard의 tiered entitlement는 구매 AWS 계정에 발급되며 특정 EC2 인스턴스에 고정되지 않습니다.
+계약 기간에는 구매자가 같은 AMI로 여러 인스턴스를 실행할 수 있으므로, 사용자 상한이 설치별인지 구매 계정 전체인지 출시 전에 확정해야 합니다.
+구매 계정 전체 상한이라면 여러 인스턴스가 공유하는 별도 라이선스 상태 관리가 필요합니다.
 
 ### 상품명과 AMI 설명의 정합성
 

--- a/aws/marketplace/SOURCES.md
+++ b/aws/marketplace/SOURCES.md
@@ -30,6 +30,7 @@ AWS Marketplace 정책과 포털 필드는 변경될 수 있으므로 실제 제
 
 ## QueryPie 공식 문서
 
+- [QueryPie ACP 가격 정책 - 2026 최신](https://querypie.atlassian.net/wiki/spaces/QPBusiness/pages/2311061525/QueryPie+ACP+-+2026): Community와 Standard의 기준 SKU, 기본 사용자 수, 연간 구독 정책
 - [QueryPie EULA](https://www.querypie.com/eula): 모든 에디션의 일반 사용권 조항과 Community License 추가 조항
 - [QueryPie ACP product page](https://www.querypie.com/en/solutions/acp): ACP 범위, 핵심 기능, 통합 대상
 - [QueryPie ACP overview](https://docs.querypie.com/en/overview): 세분화된 접근 제어, 통합 인터페이스, 모니터링, 워크플로

--- a/aws/marketplace/SOURCES.md
+++ b/aws/marketplace/SOURCES.md
@@ -18,10 +18,12 @@ AWS Marketplace 정책과 포털 필드는 변경될 수 있으므로 실제 제
 - [AMI product checklist](https://docs.aws.amazon.com/marketplace/latest/userguide/aws-marketplace-listing-checklist.html): 출시 전 제품과 이미지 점검표
 - [Creating AMI and container product usage instructions](https://docs.aws.amazon.com/marketplace/latest/userguide/ami-container-product-usage-instructions.html): 사용, 상태 점검, 백업, 암호화, 업그레이드 지침 요구 사항
 - [AMI product pricing](https://docs.aws.amazon.com/marketplace/latest/userguide/pricing-ami-products.html): Free, BYOL, Hourly, Usage, Contract 가격 모델
+- [Product pricing](https://docs.aws.amazon.com/marketplace/latest/userguide/pricing.html): Public Listing의 USD 가격과 Marketplace 소프트웨어 요금 수납
 - [Contract pricing for AMI products](https://docs.aws.amazon.com/marketplace/latest/userguide/ami-contracts.html): tiered와 non-tiered 계약 차원, 기간, 가격 필드
 - [Associating licenses with AMI products](https://docs.aws.amazon.com/marketplace/latest/userguide/ami-license-manager-integration.html): tiered entitlement, CheckoutLicense, 구매자 IAM 권한과 실행 흐름
 - [Subscribing to an AMI contract product](https://docs.aws.amazon.com/marketplace/latest/buyerguide/sub-public-AMI-contract.html): 구매자의 계약 옵션 선택과 License Manager 라이선스 생성
 - [Buying and launching an AMI product](https://docs.aws.amazon.com/marketplace/latest/buyerguide/tutorial-buying-ami.html): 버전·리전 선택과 EC2 실행 절차
+- [AWS Marketplace Seller Tax Grid](https://aws.amazon.com/tax-help/marketplace-sellers/tax-grid/): 구매자·판매자 국가별 간접세 징수와 청구 주체
 - [Submitting your product for publication](https://docs.aws.amazon.com/marketplace/latest/userguide/product-submission.html): 로고 규격, PLF, 스캔, 검토 기간, 최종 점검
 - [Refunds and cancellations](https://docs.aws.amazon.com/marketplace/latest/userguide/refunds.html): 유료 상품 환불 정책과 연락 방법 요구 사항
 - [Product categories](https://docs.aws.amazon.com/marketplace/latest/buyerguide/buyer-product-categories.html): `Security` 카테고리 정의

--- a/aws/marketplace/SOURCES.md
+++ b/aws/marketplace/SOURCES.md
@@ -2,7 +2,7 @@
 
 ## 조사 기준일
 
-2026-08-07에 확인한 공식 문서를 기준으로 작성했습니다.
+2026-08-13에 확인한 공식 문서를 기준으로 작성했습니다.
 AWS Marketplace 정책과 포털 필드는 변경될 수 있으므로 실제 제출 직전에 다시 확인해야 합니다.
 
 ## AWS Marketplace 공식 문서
@@ -18,6 +18,10 @@ AWS Marketplace 정책과 포털 필드는 변경될 수 있으므로 실제 제
 - [AMI product checklist](https://docs.aws.amazon.com/marketplace/latest/userguide/aws-marketplace-listing-checklist.html): 출시 전 제품과 이미지 점검표
 - [Creating AMI and container product usage instructions](https://docs.aws.amazon.com/marketplace/latest/userguide/ami-container-product-usage-instructions.html): 사용, 상태 점검, 백업, 암호화, 업그레이드 지침 요구 사항
 - [AMI product pricing](https://docs.aws.amazon.com/marketplace/latest/userguide/pricing-ami-products.html): Free, BYOL, Hourly, Usage, Contract 가격 모델
+- [Contract pricing for AMI products](https://docs.aws.amazon.com/marketplace/latest/userguide/ami-contracts.html): tiered와 non-tiered 계약 차원, 기간, 가격 필드
+- [Associating licenses with AMI products](https://docs.aws.amazon.com/marketplace/latest/userguide/ami-license-manager-integration.html): tiered entitlement, CheckoutLicense, 구매자 IAM 권한과 실행 흐름
+- [Subscribing to an AMI contract product](https://docs.aws.amazon.com/marketplace/latest/buyerguide/sub-public-AMI-contract.html): 구매자의 계약 옵션 선택과 License Manager 라이선스 생성
+- [Buying and launching an AMI product](https://docs.aws.amazon.com/marketplace/latest/buyerguide/tutorial-buying-ami.html): 버전·리전 선택과 EC2 실행 절차
 - [Submitting your product for publication](https://docs.aws.amazon.com/marketplace/latest/userguide/product-submission.html): 로고 규격, PLF, 스캔, 검토 기간, 최종 점검
 - [Refunds and cancellations](https://docs.aws.amazon.com/marketplace/latest/userguide/refunds.html): 유료 상품 환불 정책과 연락 방법 요구 사항
 - [Product categories](https://docs.aws.amazon.com/marketplace/latest/buyerguide/buyer-product-categories.html): `Security` 카테고리 정의

--- a/aws/marketplace/SUBMISSION-FIELDS.md
+++ b/aws/marketplace/SUBMISSION-FIELDS.md
@@ -40,8 +40,9 @@ AWS Marketplace Product SKU는 사용자 수와 관계없이 `QP1201E-SDS-AWS` �
 | `Standard20Users` | `Standard 20 Users` | 최대 20 active users | `12000.000 USD` |
 
 API name은 Public 출시 후 변경할 수 없으므로 애플리케이션의 entitlement 이름과 정확히 일치시켜야 합니다.
-License Manager entitlement의 Unit은 `None`이며, QueryPie는 `CheckoutLicense` 응답에 포함된 단일 API name을 10, 15, 20명의 활성 사용자 상한으로 변환합니다.
-유효한 entitlement가 없거나 만료되면 10 users를 자동 부여하지 않고 Standard Edition 활성화를 차단해야 합니다.
+License Manager entitlement의 Unit은 `None`이며, QueryPie는 `CheckoutLicense`에 가능한 세 API name을 모두 전달합니다.
+AWS가 안내하는 tiered license model과 같이 응답의 `EntitlementsAllowed`에 반환된 구매 API name 하나를 10, 15, 20명의 활성 사용자 상한으로 변환합니다.
+유효한 entitlement가 없거나, 둘 이상이거나, 알 수 없는 이름이거나, 만료되면 10 users를 자동 부여하지 않고 Standard Edition 활성화를 차단해야 합니다.
 
 고정 tier를 선택한 이유는 세 옵션만 허용하기 위해서입니다.
 Configurable entitlement를 사용하면 구매자가 임의 수량을 입력할 수 있으므로 10, 15, 20 users로 제한할 수 없습니다.

--- a/aws/marketplace/SUBMISSION-FIELDS.md
+++ b/aws/marketplace/SUBMISSION-FIELDS.md
@@ -17,6 +17,8 @@ AWS 통합 청구가 목표라면 BYOL 대신 contract pricing과 AWS entitlemen
 ## Standard Edition 계약 차원
 
 Standard Edition은 구매자가 임의 수량을 입력하는 configurable entitlement가 아니라, 미리 정의된 세 옵션 중 하나만 선택하는 tiered entitlement를 사용합니다.
+AWS Marketplace Product SKU는 사용자 수와 관계없이 `QP1201E-SDS-AWS` 하나만 사용합니다.
+10, 15, 20 users는 별도 SKU가 아니라 Contract pricing dimension으로 등록합니다.
 10 users를 최저 기본 플랜으로 제공하지만 구매 화면의 자동 선택값으로 가정하지 않습니다.
 구매자는 계약 생성 전에 10, 15, 20 users 중 하나를 명시적으로 선택해야 합니다.
 
@@ -45,6 +47,10 @@ License Manager entitlement의 Unit은 `None`이며, QueryPie는 `CheckoutLicens
 Configurable entitlement를 사용하면 구매자가 임의 수량을 입력할 수 있으므로 10, 15, 20 users로 제한할 수 없습니다.
 세부 PLF 입력값과 구매·실행 흐름은 [products/standard/12-contract-pricing.md](products/standard/12-contract-pricing.md)를 따릅니다.
 
+`QP1201E-SDS-AWS10`, `QP1201E-SDS-AWS15`, `QP1201E-SDS-AWS20`은 AWS Marketplace SKU로 등록하지 않습니다.
+`QP1201E-SAS-AWS`도 별도 Marketplace SKU나 dimension으로 등록하지 않습니다.
+내부 ERP에서 추가 사용자 매출을 분해해야 할 때만 내부 관리 코드로 사용할 수 있습니다.
+
 Public Listing에는 세전 소프트웨어 가격을 USD로 입력합니다.
 VAT, GST, 판매세 같은 간접세의 계산, 징수, 청구 주체는 구매자 국가, 판매자 소재지, 등록 상태와 Marketplace 운영 법인에 따라 달라집니다.
 따라서 VAT를 별도 가격 차원으로 추가하지 않고 상품 설명과 계약에는 `applicable taxes are additional`로 안내합니다.
@@ -54,7 +60,7 @@ VAT, GST, 판매세 같은 간접세의 계산, 징수, 청구 주체는 구매�
 
 | 입력 항목 | 제안 또는 현재 값 | 상태 |
 |-----------|-------------------|------|
-| Version title | 실제 출시 버전, 예: `11.6.5` | 출시 시 확정 |
+| Version title | `11.5.7`, `11.6.4` | 두 버전 등록 계획 확정, AMI 준비 상태 확인 필요 |
 | Release notes | 해당 버전의 보안, 기능, 수정 사항과 업데이트 중요도 | 작성 필요 |
 | Delivery option | `AMI (standalone)` | 제안 확정 |
 | Architecture | `x86_64` | 초기 출시 제안 |

--- a/aws/marketplace/SUBMISSION-FIELDS.md
+++ b/aws/marketplace/SUBMISSION-FIELDS.md
@@ -8,11 +8,40 @@
 | 상품 | 제안 가격 모델 | 이유 | 확정할 사항 |
 |------|----------------|------|-------------|
 | Community | Free | 소프트웨어 요금 없이 최대 5명의 소규모 자체 운영 환경 제공 | Marketplace 실행 시 외부 신청 없이 자동 사용 가능해야 함 |
-| Standard | AMI with contract pricing | 1년 단위, 최소 10명의 사용자 기반 라이선스와 가장 잘 맞음 | 계약 차원, 수량, 12개월 가격, entitlement 연동 |
+| Standard | AMI with contract pricing, tiered entitlement | 1년 단위로 10, 15, 20 users 중 하나를 선택하는 라이선스 | 각 tier의 12개월 가격, License Manager 연동 |
 | Enterprise | AMI with contract pricing 및 private offer | 고객별 사용자·사용량·사이트·DR 조건 협상에 적합 | 공개 가격 노출 여부, 계약 차원, private offer 운영 정책 |
 
 Standard나 Enterprise를 BYOL로 등록하면 외부 라이선스 URL을 사용할 수 있지만 AWS Marketplace는 소프트웨어 요금을 청구하지 않습니다.
 AWS 통합 청구가 목표라면 BYOL 대신 contract pricing과 AWS entitlement 또는 License Manager 연동을 사용해야 합니다.
+
+## Standard Edition 계약 차원
+
+Standard Edition은 구매자가 임의 수량을 입력하는 configurable entitlement가 아니라, 미리 정의된 세 옵션 중 하나만 선택하는 tiered entitlement를 사용합니다.
+10 users를 최저 기본 플랜으로 제공하지만 구매 화면의 자동 선택값으로 가정하지 않습니다.
+구매자는 계약 생성 전에 10, 15, 20 users 중 하나를 명시적으로 선택해야 합니다.
+
+| 입력 항목 | 공통 값 |
+|-----------|---------|
+| Pricing model | `AMI with contract pricing` |
+| License model | `Tiered` |
+| Contracts category | `Users` |
+| Contract duration | `12 months` |
+| Allow multiple purchases | `false` |
+| Quantity | `1` |
+
+| API name | Display name | 구매 권리 | 12개월 가격 |
+|----------|--------------|-----------|-------------|
+| `Standard10Users` | `Standard 10 Users` | 최대 10 active users | `[STANDARD_10_USERS_12_MONTH_RATE_USD]` |
+| `Standard15Users` | `Standard 15 Users` | 최대 15 active users | `[STANDARD_15_USERS_12_MONTH_RATE_USD]` |
+| `Standard20Users` | `Standard 20 Users` | 최대 20 active users | `[STANDARD_20_USERS_12_MONTH_RATE_USD]` |
+
+API name은 Public 출시 후 변경할 수 없으므로 애플리케이션의 entitlement 이름과 정확히 일치시켜야 합니다.
+License Manager entitlement의 Unit은 `None`이며, QueryPie는 `CheckoutLicense` 응답에 포함된 단일 API name을 10, 15, 20명의 활성 사용자 상한으로 변환합니다.
+유효한 entitlement가 없거나 만료되면 10 users를 자동 부여하지 않고 Standard Edition 활성화를 차단해야 합니다.
+
+고정 tier를 선택한 이유는 세 옵션만 허용하기 위해서입니다.
+Configurable entitlement를 사용하면 구매자가 임의 수량을 입력할 수 있으므로 10, 15, 20 users로 제한할 수 없습니다.
+세부 PLF 입력값과 구매·실행 흐름은 [products/standard/12-contract-pricing.md](products/standard/12-contract-pricing.md)를 따릅니다.
 
 ## 공통 버전 정보
 
@@ -94,7 +123,7 @@ AWS는 단순 실행 절차 외에도 다음 내용을 요구합니다.
 
 | 입력 항목 | Community | Standard | Enterprise |
 |-----------|-----------|----------|------------|
-| Pricing | Free | 12개월 contract dimension과 가격 필요 | 공개 계약 차원 또는 private offer 정책 필요 |
+| Pricing | Free | 10/15/20 users tier의 12개월 가격 필요 | 공개 계약 차원 또는 private offer 정책 필요 |
 | EULA | [QueryPie EULA](https://www.querypie.com/eula) | [QueryPie EULA](https://www.querypie.com/eula) | [QueryPie EULA](https://www.querypie.com/eula); private offer의 추가 협상 조건은 별도 검토 |
 | Country availability | 판매 가능 국가 확정 | 판매 가능 국가 확정 | 판매 가능 국가 확정 |
 | Refund policy | 소프트웨어 요금 없음, AWS 인프라 요금 제외, `support@querypie.com` 명시 | 환불 조건과 기간 확정, 연락처는 `support@querypie.com` | private offer 환불·해지 조건 확정, 연락처는 `support@querypie.com` |
@@ -111,6 +140,9 @@ AWS 인프라 요금은 QueryPie 소프트웨어 환불과 별개임을 명시�
 - [Creating AMI-based products](https://docs.aws.amazon.com/marketplace/latest/userguide/ami-single-ami-products.html)
 - [Managing versions for AMI-based products](https://docs.aws.amazon.com/marketplace/latest/userguide/single-ami-versions.html)
 - [AMI product pricing](https://docs.aws.amazon.com/marketplace/latest/userguide/pricing-ami-products.html)
+- [Contract pricing for AMI products](https://docs.aws.amazon.com/marketplace/latest/userguide/ami-contracts.html)
+- [Associating licenses with AMI products](https://docs.aws.amazon.com/marketplace/latest/userguide/ami-license-manager-integration.html)
+- [Subscribing to an AMI contract product](https://docs.aws.amazon.com/marketplace/latest/buyerguide/sub-public-AMI-contract.html)
 - [Creating AMI and container product usage instructions](https://docs.aws.amazon.com/marketplace/latest/userguide/ami-container-product-usage-instructions.html)
 - [Regions and countries](https://docs.aws.amazon.com/marketplace/latest/userguide/regions-and-countries.html)
 - [Refunds and cancellations](https://docs.aws.amazon.com/marketplace/latest/userguide/refunds.html)

--- a/aws/marketplace/SUBMISSION-FIELDS.md
+++ b/aws/marketplace/SUBMISSION-FIELDS.md
@@ -8,7 +8,7 @@
 | 상품 | 제안 가격 모델 | 이유 | 확정할 사항 |
 |------|----------------|------|-------------|
 | Community | Free | 소프트웨어 요금 없이 최대 5명의 소규모 자체 운영 환경 제공 | Marketplace 실행 시 외부 신청 없이 자동 사용 가능해야 함 |
-| Standard | AMI with contract pricing, tiered entitlement | 1년 단위로 10, 15, 20 users 중 하나를 선택하는 라이선스 | 각 tier의 12개월 가격, License Manager 연동 |
+| Standard | AMI with contract pricing, tiered entitlement | 1년 단위로 10, 15, 20 users 중 하나를 선택하는 라이선스 | License Manager 연동 |
 | Enterprise | AMI with contract pricing 및 private offer | 고객별 사용자·사용량·사이트·DR 조건 협상에 적합 | 공개 가격 노출 여부, 계약 차원, private offer 운영 정책 |
 
 Standard나 Enterprise를 BYOL로 등록하면 외부 라이선스 URL을 사용할 수 있지만 AWS Marketplace는 소프트웨어 요금을 청구하지 않습니다.
@@ -26,14 +26,16 @@ Standard Edition은 구매자가 임의 수량을 입력하는 configurable enti
 | License model | `Tiered` |
 | Contracts category | `Users` |
 | Contract duration | `12 months` |
+| Billing | 12개월 사용료 선불 |
+| Unit price basis | 사용자 1명당 연간 `USD 600`, 관련 세금 별도 |
 | Allow multiple purchases | `false` |
 | Quantity | `1` |
 
 | API name | Display name | 구매 권리 | 12개월 가격 |
 |----------|--------------|-----------|-------------|
-| `Standard10Users` | `Standard 10 Users` | 최대 10 active users | `[STANDARD_10_USERS_12_MONTH_RATE_USD]` |
-| `Standard15Users` | `Standard 15 Users` | 최대 15 active users | `[STANDARD_15_USERS_12_MONTH_RATE_USD]` |
-| `Standard20Users` | `Standard 20 Users` | 최대 20 active users | `[STANDARD_20_USERS_12_MONTH_RATE_USD]` |
+| `Standard10Users` | `Standard 10 Users` | 최대 10 active users | `6000.000 USD` |
+| `Standard15Users` | `Standard 15 Users` | 최대 15 active users | `9000.000 USD` |
+| `Standard20Users` | `Standard 20 Users` | 최대 20 active users | `12000.000 USD` |
 
 API name은 Public 출시 후 변경할 수 없으므로 애플리케이션의 entitlement 이름과 정확히 일치시켜야 합니다.
 License Manager entitlement의 Unit은 `None`이며, QueryPie는 `CheckoutLicense` 응답에 포함된 단일 API name을 10, 15, 20명의 활성 사용자 상한으로 변환합니다.
@@ -42,6 +44,11 @@ License Manager entitlement의 Unit은 `None`이며, QueryPie는 `CheckoutLicens
 고정 tier를 선택한 이유는 세 옵션만 허용하기 위해서입니다.
 Configurable entitlement를 사용하면 구매자가 임의 수량을 입력할 수 있으므로 10, 15, 20 users로 제한할 수 없습니다.
 세부 PLF 입력값과 구매·실행 흐름은 [products/standard/12-contract-pricing.md](products/standard/12-contract-pricing.md)를 따릅니다.
+
+Public Listing에는 세전 소프트웨어 가격을 USD로 입력합니다.
+VAT, GST, 판매세 같은 간접세의 계산, 징수, 청구 주체는 구매자 국가, 판매자 소재지, 등록 상태와 Marketplace 운영 법인에 따라 달라집니다.
+따라서 VAT를 별도 가격 차원으로 추가하지 않고 상품 설명과 계약에는 `applicable taxes are additional`로 안내합니다.
+실제 세금 처리는 AWS Marketplace Seller Tax Grid와 QueryPie 세무 검토 결과를 따릅니다.
 
 ## 공통 버전 정보
 
@@ -123,7 +130,7 @@ AWS는 단순 실행 절차 외에도 다음 내용을 요구합니다.
 
 | 입력 항목 | Community | Standard | Enterprise |
 |-----------|-----------|----------|------------|
-| Pricing | Free | 10/15/20 users tier의 12개월 가격 필요 | 공개 계약 차원 또는 private offer 정책 필요 |
+| Pricing | Free | 10 users `6000`, 15 users `9000`, 20 users `12000` USD, 12개월 선불 | 공개 계약 차원 또는 private offer 정책 필요 |
 | EULA | [QueryPie EULA](https://www.querypie.com/eula) | [QueryPie EULA](https://www.querypie.com/eula) | [QueryPie EULA](https://www.querypie.com/eula); private offer의 추가 협상 조건은 별도 검토 |
 | Country availability | 판매 가능 국가 확정 | 판매 가능 국가 확정 | 판매 가능 국가 확정 |
 | Refund policy | 소프트웨어 요금 없음, AWS 인프라 요금 제외, `support@querypie.com` 명시 | 환불 조건과 기간 확정, 연락처는 `support@querypie.com` | private offer 환불·해지 조건 확정, 연락처는 `support@querypie.com` |

--- a/aws/marketplace/products/community/02-sku.md
+++ b/aws/marketplace/products/community/02-sku.md
@@ -1,10 +1,11 @@
 # SKU
 
-## 제안 입력값
+## AWS 입력값
 
-`QP-ACP-AMI-COMMUNITY`
+`QP1201E-CDS-AWS`
 
-## 상태
+## 적용 기준
 
-사내 SKU 체계와 대조한 뒤 확정해야 합니다.
 SKU는 구매자에게 표시되지 않는 판매자 내부 참조 값입니다.
+Community Edition은 별도 가격 dimension 없이 이 상품 SKU 하나를 사용합니다.
+무료 소프트웨어 라이선스의 최대 활성 사용자는 5명입니다.

--- a/aws/marketplace/products/standard/02-sku.md
+++ b/aws/marketplace/products/standard/02-sku.md
@@ -1,10 +1,11 @@
 # SKU
 
-## 제안 입력값
+## AWS 입력값
 
-`QP-ACP-AMI-STANDARD`
+`QP1201E-SDS-AWS`
 
-## 상태
+## 적용 기준
 
-사내 SKU 체계와 대조한 뒤 확정해야 합니다.
 SKU는 구매자에게 표시되지 않는 판매자 내부 참조 값입니다.
+10, 15, 20 users는 별도 SKU가 아니라 Contract pricing dimension으로 구분합니다.
+AWS Marketplace에는 사용자 수가 붙은 파생 SKU나 추가 사용자 SKU를 등록하지 않습니다.

--- a/aws/marketplace/products/standard/12-contract-pricing.md
+++ b/aws/marketplace/products/standard/12-contract-pricing.md
@@ -1,0 +1,82 @@
+# Contract pricing
+
+## 결정
+
+QueryPie ACP Standard Edition은 `AMI with contract pricing`과 tiered entitlement를 사용합니다.
+구매자는 12개월 계약을 생성할 때 10, 15, 20 users 중 하나를 선택합니다.
+10 users는 최저 기본 플랜이지만 AWS 구매 화면에서 자동 선택되는 값으로 가정하지 않습니다.
+
+## AWS 입력값
+
+| Field | Value |
+|-------|-------|
+| Pricing model | `AMI with contract pricing` |
+| License model | `Tiered` |
+| Contracts category | `Users` |
+| Contract duration | `12 months` |
+| Contracts Dimension Allow Multiple Purchases | `false` |
+| Contracts Dimension Quantity | `1` |
+
+| API name | Display name | Description | Entitlement unit | 12-month rate |
+|----------|--------------|-------------|------------------|---------------|
+| `Standard10Users` | `Standard 10 Users` | `QueryPie ACP Standard Edition for up to 10 active users` | `None` | `[STANDARD_10_USERS_12_MONTH_RATE_USD]` |
+| `Standard15Users` | `Standard 15 Users` | `QueryPie ACP Standard Edition for up to 15 active users` | `None` | `[STANDARD_15_USERS_12_MONTH_RATE_USD]` |
+| `Standard20Users` | `Standard 20 Users` | `QueryPie ACP Standard Edition for up to 20 active users` | `None` | `[STANDARD_20_USERS_12_MONTH_RATE_USD]` |
+
+세 API name은 Public 출시 후 변경하지 않습니다.
+세 tier 모두 같은 계약 기간을 제공해야 합니다.
+대괄호로 표시한 USD 가격을 확정한 뒤 Product Load Form 또는 Partner Central에 입력합니다.
+
+## 애플리케이션 권리 적용
+
+QueryPie는 최초 부팅과 정기 검증 시 AWS Marketplace가 발급한 License Manager 라이선스를 확인합니다.
+애플리케이션은 `CheckoutLicense` 요청에 세 entitlement name을 모두 전달하고 응답에 포함된 하나의 tier를 적용합니다.
+
+| 반환된 entitlement | 적용할 활성 사용자 상한 |
+|---------------------|-------------------------|
+| `Standard10Users` | 10 |
+| `Standard15Users` | 15 |
+| `Standard20Users` | 20 |
+
+유효한 entitlement가 없거나 만료되면 Standard Edition을 활성화하지 않습니다.
+외부 신청 폼, 이메일 입력 또는 별도 라이선스 파일 업로드를 요구하지 않습니다.
+EC2 인스턴스 프로파일에는 최소한 다음 작업이 필요합니다.
+
+- `license-manager:CheckoutLicense`
+- `license-manager:GetLicense`
+- `license-manager:ListReceivedLicenses`
+
+AWS 공식 예시는 갱신과 반환을 위해 `ExtendLicenseConsumption`과 `CheckInLicense`도 포함합니다.
+실제 런타임 호출 방식이 확정되면 사용하는 작업만 남겨 최소 권한 정책으로 검증합니다.
+
+## 구매 및 EC2 실행 흐름
+
+1. 구매자가 QueryPie ACP Standard Edition의 Public 상품에서 `Continue to Subscribe`를 선택합니다.
+2. 12개월 계약과 자동 갱신 여부를 선택합니다.
+3. Contract options에서 `Standard 10 Users`, `Standard 15 Users`, `Standard 20 Users` 중 하나를 선택하고 계약을 생성합니다.
+4. AWS Marketplace가 구매자 계정의 License Manager에 선택한 tier의 라이선스를 생성할 때까지 기다립니다. 처리에는 최대 10분이 걸릴 수 있습니다.
+5. `Continue to Configuration`에서 AMI delivery method, QueryPie 버전, AWS 리전을 선택합니다.
+6. `Continue to Launch`에서 1-Click 또는 EC2 Console을 선택합니다.
+7. EC2 Console을 사용하는 경우 인스턴스 타입, VPC, 서브넷, 보안 그룹, 키 페어, EBS를 설정하고 Marketplace AMI로 인스턴스를 생성합니다.
+8. 인스턴스에 License Manager 조회 권한이 있는 IAM instance profile을 연결합니다.
+9. QueryPie 최초 부팅 서비스가 entitlement를 확인하고 구매한 활성 사용자 상한을 적용합니다.
+
+계약 라이선스는 특정 EC2 인스턴스에 고정되지 않으며 계약 기간에는 같은 AMI로 여러 인스턴스를 실행할 수 있습니다.
+따라서 10, 15, 20 users가 설치별 상한인지 구매 AWS 계정 전체 상한인지 별도로 확정해야 합니다.
+구매 계정 전체 상한이면 여러 인스턴스가 공통 상태를 확인하는 라이선스 제어가 추가로 필요합니다.
+
+## 검증 기준
+
+- Limited 상품에서 세 tier가 동시에 노출되고 구매자가 하나만 선택할 수 있습니다.
+- 각 tier 구매 후 License Manager에 예상 API name의 라이선스가 생성됩니다.
+- 10, 15, 20 users 상한이 각각 적용됩니다.
+- entitlement가 없거나 만료되면 Standard Edition이 활성화되지 않습니다.
+- 계약 변경으로 상위 tier를 선택하면 QueryPie가 갱신된 권리를 반영합니다.
+- AMI 버전과 리전을 선택해 EC2 인스턴스를 정상 생성할 수 있습니다.
+
+## 공식 근거
+
+- [Contract pricing for AMI products](https://docs.aws.amazon.com/marketplace/latest/userguide/ami-contracts.html)
+- [Associating licenses with AMI products](https://docs.aws.amazon.com/marketplace/latest/userguide/ami-license-manager-integration.html)
+- [Subscribing to an AMI contract product](https://docs.aws.amazon.com/marketplace/latest/buyerguide/sub-public-AMI-contract.html)
+- [Buying and launching an AMI product](https://docs.aws.amazon.com/marketplace/latest/buyerguide/tutorial-buying-ami.html)

--- a/aws/marketplace/products/standard/12-contract-pricing.md
+++ b/aws/marketplace/products/standard/12-contract-pricing.md
@@ -14,18 +14,25 @@ QueryPie ACP Standard Edition은 `AMI with contract pricing`과 tiered entitleme
 | License model | `Tiered` |
 | Contracts category | `Users` |
 | Contract duration | `12 months` |
+| Billing | 12개월 사용료 선불 |
+| Unit price basis | 사용자 1명당 연간 `USD 600`, 관련 세금 별도 |
 | Contracts Dimension Allow Multiple Purchases | `false` |
 | Contracts Dimension Quantity | `1` |
 
 | API name | Display name | Description | Entitlement unit | 12-month rate |
 |----------|--------------|-------------|------------------|---------------|
-| `Standard10Users` | `Standard 10 Users` | `QueryPie ACP Standard Edition for up to 10 active users` | `None` | `[STANDARD_10_USERS_12_MONTH_RATE_USD]` |
-| `Standard15Users` | `Standard 15 Users` | `QueryPie ACP Standard Edition for up to 15 active users` | `None` | `[STANDARD_15_USERS_12_MONTH_RATE_USD]` |
-| `Standard20Users` | `Standard 20 Users` | `QueryPie ACP Standard Edition for up to 20 active users` | `None` | `[STANDARD_20_USERS_12_MONTH_RATE_USD]` |
+| `Standard10Users` | `Standard 10 Users` | `QueryPie ACP Standard Edition for up to 10 active users` | `None` | `6000.000 USD` |
+| `Standard15Users` | `Standard 15 Users` | `QueryPie ACP Standard Edition for up to 15 active users` | `None` | `9000.000 USD` |
+| `Standard20Users` | `Standard 20 Users` | `QueryPie ACP Standard Edition for up to 20 active users` | `None` | `12000.000 USD` |
 
 세 API name은 Public 출시 후 변경하지 않습니다.
 세 tier 모두 같은 계약 기간을 제공해야 합니다.
-대괄호로 표시한 USD 가격을 확정한 뒤 Product Load Form 또는 Partner Central에 입력합니다.
+12-month rate에는 숫자 금액을 Product Load Form 또는 Partner Central이 요구하는 형식으로 입력합니다.
+
+Public Listing에는 세전 소프트웨어 가격을 USD로 입력합니다.
+VAT, GST, 판매세 같은 간접세의 계산, 징수, 청구 주체는 구매자 국가와 거래 조건에 따라 달라지므로 VAT를 별도 계약 차원으로 추가하지 않습니다.
+상품과 계약 문안에는 `Applicable taxes are additional and handled according to AWS Marketplace tax rules.`를 사용합니다.
+세금 처리는 AWS Marketplace Seller Tax Grid와 QueryPie 세무 검토 결과를 따릅니다.
 
 ## 애플리케이션 권리 적용
 
@@ -77,6 +84,8 @@ AWS 공식 예시는 갱신과 반환을 위해 `ExtendLicenseConsumption`과 `C
 ## 공식 근거
 
 - [Contract pricing for AMI products](https://docs.aws.amazon.com/marketplace/latest/userguide/ami-contracts.html)
+- [Product pricing](https://docs.aws.amazon.com/marketplace/latest/userguide/pricing.html)
 - [Associating licenses with AMI products](https://docs.aws.amazon.com/marketplace/latest/userguide/ami-license-manager-integration.html)
 - [Subscribing to an AMI contract product](https://docs.aws.amazon.com/marketplace/latest/buyerguide/sub-public-AMI-contract.html)
 - [Buying and launching an AMI product](https://docs.aws.amazon.com/marketplace/latest/buyerguide/tutorial-buying-ami.html)
+- [AWS Marketplace Seller Tax Grid](https://aws.amazon.com/tax-help/marketplace-sellers/tax-grid/)

--- a/aws/marketplace/products/standard/12-contract-pricing.md
+++ b/aws/marketplace/products/standard/12-contract-pricing.md
@@ -40,7 +40,11 @@ VAT, GST, 판매세 같은 간접세의 계산, 징수, 청구 주체는 구매�
 ## 애플리케이션 권리 적용
 
 QueryPie는 최초 부팅과 정기 검증 시 AWS Marketplace가 발급한 License Manager 라이선스를 확인합니다.
-애플리케이션은 `CheckoutLicense` 요청에 세 entitlement name을 모두 전달하고 응답에 포함된 하나의 tier를 적용합니다.
+AWS가 안내하는 tiered license model에 따라 애플리케이션은 `CheckoutLicense` 요청에 가능한 세 entitlement name을 모두 전달하고, 응답의 `EntitlementsAllowed`에 반환된 구매 tier를 적용합니다.
+응답에는 `Standard10Users`, `Standard15Users`, `Standard20Users` 중 정확히 하나만 있어야 합니다.
+checkout이 실패하거나 entitlement가 없거나 둘 이상이거나, 알 수 없는 이름이거나, 라이선스가 만료·비활성 상태이면 활성화를 차단합니다.
+계약 갱신 또는 tier 변경을 반영할 수 있도록 checkout을 정기적으로 반복합니다.
+`ListReceivedLicenses`와 `GetLicense`는 받은 라이선스의 조회, 상태 확인 및 문제 진단에 사용합니다.
 
 | 반환된 entitlement | 적용할 활성 사용자 상한 |
 |---------------------|-------------------------|
@@ -48,7 +52,6 @@ QueryPie는 최초 부팅과 정기 검증 시 AWS Marketplace가 발급한 Lice
 | `Standard15Users` | 15 |
 | `Standard20Users` | 20 |
 
-유효한 entitlement가 없거나 만료되면 Standard Edition을 활성화하지 않습니다.
 외부 신청 폼, 이메일 입력 또는 별도 라이선스 파일 업로드를 요구하지 않습니다.
 EC2 인스턴스 프로파일에는 최소한 다음 작업이 필요합니다.
 
@@ -69,7 +72,7 @@ AWS 공식 예시는 갱신과 반환을 위해 `ExtendLicenseConsumption`과 `C
 6. `Continue to Launch`에서 1-Click 또는 EC2 Console을 선택합니다.
 7. EC2 Console을 사용하는 경우 인스턴스 타입, VPC, 서브넷, 보안 그룹, 키 페어, EBS를 설정하고 Marketplace AMI로 인스턴스를 생성합니다.
 8. 인스턴스에 License Manager 조회 권한이 있는 IAM instance profile을 연결합니다.
-9. QueryPie 최초 부팅 서비스가 entitlement를 확인하고 구매한 활성 사용자 상한을 적용합니다.
+9. QueryPie 최초 부팅 서비스가 세 tier를 checkout 요청하고, 응답에 반환된 구매 entitlement 하나의 활성 사용자 상한을 적용합니다.
 
 계약 라이선스는 특정 EC2 인스턴스에 고정되지 않으며 계약 기간에는 같은 AMI로 여러 인스턴스를 실행할 수 있습니다.
 따라서 10, 15, 20 users가 설치별 상한인지 구매 AWS 계정 전체 상한인지 별도로 확정해야 합니다.
@@ -79,8 +82,9 @@ AWS 공식 예시는 갱신과 반환을 위해 `ExtendLicenseConsumption`과 `C
 
 - Limited 상품에서 세 tier가 동시에 노출되고 구매자가 하나만 선택할 수 있습니다.
 - 각 tier 구매 후 License Manager에 예상 API name의 라이선스가 생성됩니다.
+- QueryPie가 세 tier를 checkout 요청했을 때 구매한 entitlement 하나만 반환됩니다.
 - 10, 15, 20 users 상한이 각각 적용됩니다.
-- entitlement가 없거나 만료되면 Standard Edition이 활성화되지 않습니다.
+- entitlement가 없거나, 둘 이상이거나, 알 수 없는 이름이거나, 만료되면 Standard Edition이 활성화되지 않습니다.
 - 계약 변경으로 상위 tier를 선택하면 QueryPie가 갱신된 권리를 반영합니다.
 - AMI 버전과 리전을 선택해 EC2 인스턴스를 정상 생성할 수 있습니다.
 

--- a/aws/marketplace/products/standard/12-contract-pricing.md
+++ b/aws/marketplace/products/standard/12-contract-pricing.md
@@ -3,6 +3,7 @@
 ## 결정
 
 QueryPie ACP Standard Edition은 `AMI with contract pricing`과 tiered entitlement를 사용합니다.
+AWS Marketplace Product SKU는 `QP1201E-SDS-AWS` 하나만 사용합니다.
 구매자는 12개월 계약을 생성할 때 10, 15, 20 users 중 하나를 선택합니다.
 10 users는 최저 기본 플랜이지만 AWS 구매 화면에서 자동 선택되는 값으로 가정하지 않습니다.
 
@@ -10,6 +11,7 @@ QueryPie ACP Standard Edition은 `AMI with contract pricing`과 tiered entitleme
 
 | Field | Value |
 |-------|-------|
+| Product SKU | `QP1201E-SDS-AWS` |
 | Pricing model | `AMI with contract pricing` |
 | License model | `Tiered` |
 | Contracts category | `Users` |
@@ -28,6 +30,7 @@ QueryPie ACP Standard Edition은 `AMI with contract pricing`과 tiered entitleme
 세 API name은 Public 출시 후 변경하지 않습니다.
 세 tier 모두 같은 계약 기간을 제공해야 합니다.
 12-month rate에는 숫자 금액을 Product Load Form 또는 Partner Central이 요구하는 형식으로 입력합니다.
+사용자 수별 파생 SKU와 `QP1201E-SAS-AWS`는 AWS Marketplace에 등록하지 않습니다.
 
 Public Listing에는 세전 소프트웨어 가격을 USD로 입력합니다.
 VAT, GST, 판매세 같은 간접세의 계산, 징수, 청구 주체는 구매자 국가와 거래 조건에 따라 달라지므로 VAT를 별도 계약 차원으로 추가하지 않습니다.


### PR DESCRIPTION
## 목적

QueryPie ACP Community Edition과 Standard Edition의 AWS Marketplace 상품 구조, SKU, 사용자별 연간 가격과 등록 절차를 최종 확정합니다.

## 확정 사항

- Community Product SKU: `QP1201E-CDS-AWS`
- Standard Product SKU: `QP1201E-SDS-AWS`
- Standard는 사용자 수별 파생 SKU 없이 하나의 Product SKU만 사용
- 10/15/20 users를 tiered Contract pricing dimension으로 구분
- 사용자당 연간 USD 600 기준으로 USD 6,000 / 9,000 / 12,000 선불 가격 적용
- Community와 Standard를 별도 Public Single AMI 상품으로 등록
- 각 상품에 11.5.7과 11.6.4 버전 등록 계획 수립
- Limited 상품 생성, AMI 스캔, 구매·EC2 실행, entitlement 검증 후 Public 전환

## 주요 문서

- `aws/marketplace/REGISTRATION-PLAN.md`: 최종 등록 계획과 완료 조건
- `aws/marketplace/SUBMISSION-FIELDS.md`: Partner Central 입력값
- `aws/marketplace/products/standard/12-contract-pricing.md`: Standard 가격 dimension과 구매 흐름
- Community/Standard `02-sku.md`: 확정 Product SKU

## 검증

- `git diff --check` 통과
- 기존 임시 Community/Standard SKU 제거 확인
- 확정 Product SKU의 관련 문서 정합성 확인
- Contract dimension 3개 고유성 확인
- 10/15/20 users와 사용자당 USD 600 가격 산식 확인
- Markdown 표 열 개수 확인

## Public 제출 전 남은 작업

- Community 외부 라이선스 신청 없는 자동 활성화 구현
- Standard License Manager `CheckoutLicense` 연동
- 다중 EC2 인스턴스의 사용자 상한 적용 범위 확정
- 11.6.4 판매자 계정 AMI 준비 및 스캔
- 구매 국가와 환불 조건 확정
- Limited 구매와 EC2 실행 검증